### PR TITLE
Add inline button callbacks

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,5 +1,5 @@
 import os
-from telebot import TeleBot
+from telebot import TeleBot, types
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -9,3 +9,14 @@ print("🧪 BOT TOKEN:", TELEGRAM_BOT_TOKEN)
 CHAT_ID = os.getenv("CHAT_ID")
 
 bot = TeleBot(TELEGRAM_BOT_TOKEN)
+
+
+@bot.callback_query_handler(func=lambda call: True)
+def handle_inline_buttons(call: types.CallbackQuery) -> None:
+    """Handle simple inline button confirmations."""
+    if call.data == "confirmbuy_ETH":
+        bot.answer_callback_query(call.id)
+        bot.send_message(call.message.chat.id, "🟢 Купівля ETH підтверджена!")
+    elif call.data == "confirmsell_BTC":
+        bot.answer_callback_query(call.id)
+        bot.send_message(call.message.chat.id, "🔴 Продаж BTC підтверджена!")


### PR DESCRIPTION
## Summary
- handle confirmation callbacks in `telegram_bot.py`

## Testing
- `python -m py_compile telegram_bot.py`
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Binance API access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68414285846c832987a333310ca89316