### PR TITLE
Implement simplified telegram bot handlers

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -6,21 +6,35 @@ from daily_analysis import generate_zarobyty_report
 load_dotenv()
 
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
-print("🧪 BOT TOKEN:", TELEGRAM_BOT_TOKEN)
-CHAT_ID = os.getenv("CHAT_ID")
 
 bot = TeleBot(TELEGRAM_BOT_TOKEN)
 
 
 @bot.message_handler(commands=["zarobyty"])
-def handle_zarobyty(message):
-    """Send profit report with inline buttons."""
+def handle_zarobyty(message: types.Message) -> None:
+    """Send profit report with buy/sell buttons."""
     report_text = generate_zarobyty_report()
 
     markup = types.InlineKeyboardMarkup()
     markup.row(
-        types.InlineKeyboardButton("🔴 Продати BTC", callback_data="confirmsell_BTC"),
         types.InlineKeyboardButton("🟢 Купити ETH", callback_data="confirmbuy_ETH"),
+        types.InlineKeyboardButton("🔴 Продати BTC", callback_data="confirmsell_BTC"),
     )
 
     bot.send_message(message.chat.id, report_text, reply_markup=markup)
+
+
+@bot.callback_query_handler(func=lambda call: True)
+def handle_callback(call: types.CallbackQuery) -> None:
+    data = call.data
+    if data.startswith("confirmbuy_") or data.startswith("confirmsell_"):
+        action, symbol = data.split("_", 1)
+        verb = "купівлю" if action == "confirmbuy" else "продаж"
+        bot.answer_callback_query(call.id, text="Підтверджено")
+        bot.send_message(call.message.chat.id, f"✅ Ви підтвердили {verb} {symbol}")
+    else:
+        bot.answer_callback_query(call.id, text="Невідома дія")
+
+
+if __name__ == "__main__":
+    bot.infinity_polling()


### PR DESCRIPTION
## Summary
- add basic bot callback handler
- support /zarobyty message handler with inline buy/sell buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68417f914d9083299ff26fcf1a78cf5f