### PR TITLE
Add script to update repo and restart service

### DIFF
--- a/update-from-github.sh
+++ b/update-from-github.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Fetch latest code and reset to origin/dev
+git fetch origin
+git reset --hard origin/dev
+
+# Restart the systemd service
+sudo systemctl restart crypto-bot.service


### PR DESCRIPTION
## Summary
- add `update-from-github.sh` to fetch `origin/dev` and restart the crypto-bot service
- make the script executable

## Testing
- `bash -n update-from-github.sh`

------
https://chatgpt.com/codex/tasks/task_e_684185bb19c88329a76def27327ca0a4