### PR TITLE
Fix bot startup on dev branch

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -17,7 +17,13 @@ BINANCE_SECRET_KEY = os.getenv("BINANCE_SECRET_KEY")
 BINANCE_BASE_URL = "https://api.binance.com"
 
 # 🧩 Ініціалізація клієнта Binance
-client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_SECRET_KEY)
+# ping=False запобігає зверненню до API під час ініціалізації, що
+# важливо для середовищ без інтернет-доступу
+client = Client(
+    api_key=BINANCE_API_KEY,
+    api_secret=BINANCE_SECRET_KEY,
+    ping=False,
+)
 # 🕒 Отримання поточного timestamp для підпису запитів
 def get_timestamp() -> int:
     return int(time.time() * 1000)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -9,6 +9,9 @@ load_dotenv()
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 CHAT_ID = int(os.getenv("CHAT_ID", "0"))
 
+if not TELEGRAM_BOT_TOKEN:
+    raise RuntimeError("Missing TELEGRAM_BOT_TOKEN environment variable")
+
 bot = TeleBot(TELEGRAM_BOT_TOKEN)
 
 


### PR DESCRIPTION
## Summary
- avoid Binance ping on init to prevent startup crash
- validate TELEGRAM_BOT_TOKEN early

## Testing
- `python -m py_compile telegram_bot.py`
- `python -m py_compile binance_api.py`
- `pytest -q` *(fails: Binance API access requires internet)*

------
https://chatgpt.com/codex/tasks/task_e_6841cac1be948329bca16019ac5a0b70