### PR TITLE
Fix: downgrade aiogram to 2.25.2 and restore executor-based bot

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -5,7 +5,7 @@ import requests
 from dotenv import load_dotenv
 from binance_api import get_current_portfolio, get_full_asset_info
 from typing import Dict, List, Tuple, Optional
-from aiogram import Bot
+from aiogram import Bot, Dispatcher, types, executor
 
 
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,17 @@
-from aiogram import executor
-from telegram_bot import dp
+import os
+from dotenv import load_dotenv
+from aiogram import Bot, Dispatcher, types, executor
+
+load_dotenv()
+
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+if not TELEGRAM_TOKEN:
+    raise RuntimeError("Missing TELEGRAM_TOKEN environment variable")
+
+bot = Bot(token=TELEGRAM_TOKEN)
+dp = Dispatcher(bot)
+
+import telegram_bot  # noqa: F401  # register handlers
 
 if __name__ == "__main__":
     executor.start_polling(dp, skip_updates=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 openai>=1.0.0,<2.0.0
 requests>=2.25.0,<3.0.0
-aiogram>=2.25,<3.0
+aiogram==2.25.2
 python-binance>=1.0.17,<2.0.0
 python-dotenv>=1.0.0,<2.0.0

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,7 +1,7 @@
 """Telegram bot configuration and handlers."""
 
 import os
-from aiogram import Bot, Dispatcher, types
+from aiogram import Bot, Dispatcher, types, executor
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -19,5 +19,5 @@ dp = Dispatcher(bot)
 @dp.message_handler(commands=["zarobyty"])
 async def handle_zarobyty(message: types.Message) -> None:
     """Minimal handler responding that the bot works and sees .env."""
-    await message.answer("✅ Бот працює і бачить .env")
+    await message.answer("✅ Бот працює: /zarobyty активна")
 


### PR DESCRIPTION
## Summary
- downgrade aiogram requirement to `2.25.2`
- restore executor-based initialization in `main.py`
- update telegram bot setup and command handler
- adjust daily analysis imports

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6841e30aa7a08329a7c9cbfa71bf69c8