### PR TITLE
Fix: fallback for TELEGRAM_TOKEN and full repair for server launch

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,9 +5,9 @@ from aiogram.utils import executor
 
 load_dotenv()
 
-TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
-if not TELEGRAM_TOKEN:
-    raise RuntimeError("Missing TELEGRAM_TOKEN environment variable")
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN", "PLACEHOLDER")
+if TELEGRAM_TOKEN == "PLACEHOLDER":
+    print("\u26a0\ufe0f Warning: TELEGRAM_TOKEN is empty. Make sure .env is loaded on server.")
 
 bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher(bot)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.25.0,<3.0.0
 aiogram==2.25.2
 python-binance>=1.0.17,<2.0.0
 python-dotenv>=1.0.0,<2.0.0
+apscheduler>=3.9.0,<4.0.0

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -7,11 +7,11 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN", "PLACEHOLDER")
 ADMIN_CHAT_ID = int(os.getenv("ADMIN_CHAT_ID", os.getenv("CHAT_ID", "0")))
 
-if not TELEGRAM_TOKEN:
-    raise RuntimeError("Missing TELEGRAM_TOKEN environment variable")
+if TELEGRAM_TOKEN == "PLACEHOLDER":
+    print("\u26a0\ufe0f Warning: TELEGRAM_TOKEN is empty. Make sure .env is loaded on server.")
 
 bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher(bot)
@@ -36,6 +36,12 @@ async def handle_zarobyty(message: types.Message) -> None:
         InlineKeyboardButton("Підтвердити", callback_data="confirm")
     )
     await message.answer(report, reply_markup=keyboard)
+
+
+@dp.callback_query_handler(lambda c: c.data == "confirm")
+async def handle_confirm_callback(callback_query: types.CallbackQuery) -> None:
+    """Respond to inline confirmation button press."""
+    await callback_query.answer("Підтверджено ✅", show_alert=True)
 
 
 @dp.message_handler(commands=["stats"])


### PR DESCRIPTION
## Summary
- adjust bot startup to warn rather than crash if `TELEGRAM_TOKEN` is not set
- add inline button confirmation handler
- update requirements with APScheduler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install -r requirements.txt` *(fails: build errors due to dependency conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_6841eb37b32c83299f754ce330a369eb