### PR TITLE
Fix: use explicit ~/.env path for TELEGRAM_TOKEN in telegram_bot.py

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -4,10 +4,13 @@ import os
 from dotenv import load_dotenv
 from aiogram import Bot, Dispatcher, types
 
-load_dotenv()  # МАЄ стояти ДО os.getenv
+load_dotenv(dotenv_path=os.path.expanduser("~/.env"))
+
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN", "PLACEHOLDER")
 if TELEGRAM_TOKEN == "PLACEHOLDER":
-    print("⚠️ Warning: TELEGRAM_TOKEN is empty. Make sure .env is loaded on server.")
+    print(
+        "⚠️ Warning: TELEGRAM_TOKEN is empty. Make sure .env is loaded on server."
+    )
 
 bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher(bot)


### PR DESCRIPTION
## Summary
- load `~/.env` explicitly in `telegram_bot.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_6841fb056c848329b90e28fb11652dc7