### PR TITLE
Fix: async scheduler and env path cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# Example configuration. Place this file at /root/.env on the server.
 TELEGRAM_TOKEN=your_telegram_token
 ADMIN_CHAT_ID=123456789
 OPENAI_API_KEY=your_openai_key

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -27,4 +27,4 @@ jobs:
           ADMIN_CHAT_ID: ${{ secrets.ADMIN_CHAT_ID }}
           BINANCE_API_KEY: ${{ secrets.BINANCE_API_KEY }}
           BINANCE_SECRET_KEY: ${{ secrets.BINANCE_SECRET_KEY }}
-        run: python daily_analysis.py
+        run: python run_daily_analysis.py

--- a/daily.yml
+++ b/daily.yml
@@ -28,4 +28,4 @@ jobs:
           BINANCE_API_KEY: ${{ secrets.BINANCE_API_KEY }}
           BINANCE_SECRET_KEY: ${{ secrets.BINANCE_SECRET_KEY }}
           ADMIN_CHAT_ID: ${{ secrets.ADMIN_CHAT_ID }}
-        run: python daily_analysis.py
+        run: python run_daily_analysis.py

--- a/main.py
+++ b/main.py
@@ -14,9 +14,21 @@ if os.getenv("TELEGRAM_TOKEN", "PLACEHOLDER") == "PLACEHOLDER":
 
 async def main():
     scheduler = AsyncIOScheduler(timezone="Europe/Kiev")
-    scheduler.add_job(daily_analysis_task, "cron", hour=8, minute=55, args=(bot, ADMIN_CHAT_ID))
-    scheduler.add_job(send_zarobyty_forecast, "cron", hour=9, minute=0, args=(bot, ADMIN_CHAT_ID))
-    await scheduler.start()
+    scheduler.add_job(
+        daily_analysis_task,
+        "cron",
+        hour=8,
+        minute=55,
+        args=(bot, ADMIN_CHAT_ID),
+    )
+    scheduler.add_job(
+        send_zarobyty_forecast,
+        "cron",
+        hour=9,
+        minute=0,
+        args=(bot, ADMIN_CHAT_ID),
+    )
+    scheduler.start()
     await dp.start_polling()
 
 

--- a/restart_bot.sh
+++ b/restart_bot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export $(grep -v '^#' /root/telegram-crypto-bot-github/.env | xargs)
+export $(grep -v '^#' /root/.env | xargs)
 
 
 echo "🔁 Перезапуск Telegram GPT-бота..."

--- a/systemd/crypto-bot.service
+++ b/systemd/crypto-bot.service
@@ -11,7 +11,7 @@ RestartSec=5
 StandardOutput=journal
 StandardError=journal
 Environment=PYTHONUNBUFFERED=1
-EnvironmentFile=/root/telegram-crypto-bot-github/.env
+EnvironmentFile=/root/.env
 
 [Install]
 WantedBy=multi-user.target

--- a/update_all.sh
+++ b/update_all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export $(cat /root/telegram-crypto-bot-github/.env | xargs)
+export $(cat /root/.env | xargs)
 
 echo "📦 Зберігаю актуальні файли"
 git add main.py


### PR DESCRIPTION
## Summary
- ensure `.env` variables load from `/root/.env`
- run APScheduler inside async `main` with `asyncio.run`
- update systemd unit and helper scripts for new env path
- run daily workflow via `run_daily_analysis.py`
- note server `.env` location in example file

## Testing
- `python -m py_compile main.py daily_analysis.py telegram_bot.py binance_api.py run_daily_analysis.py`
- `pytest -q` *(fails: ModuleNotFoundError and API restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6841fed4aad88329a7b47ee374621d8d