### PR TITLE
Fix Telegram bot startup and handlers

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import os
-import asyncio
 from dotenv import load_dotenv
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from aiogram.utils import executor
 
 from telegram_bot import bot, dp, ADMIN_CHAT_ID  # registers handlers
 from daily_analysis import daily_analysis_task, send_zarobyty_forecast
@@ -9,10 +9,10 @@ from daily_analysis import daily_analysis_task, send_zarobyty_forecast
 load_dotenv(dotenv_path=os.path.expanduser("~/.env"))
 
 if os.getenv("TELEGRAM_TOKEN", "PLACEHOLDER") == "PLACEHOLDER":
-    print("⚠️ Warning: TELEGRAM_TOKEN is empty. Make sure .env is loaded on server.")
+    print("⚠️ Warning: .env not loaded. This is expected in Codex.")
 
 
-async def main():
+async def on_startup(dp):
     scheduler = AsyncIOScheduler(timezone="Europe/Kiev")
     scheduler.add_job(
         daily_analysis_task,
@@ -29,8 +29,7 @@ async def main():
         args=(bot, ADMIN_CHAT_ID),
     )
     scheduler.start()
-    await dp.start_polling()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    executor.start_polling(dp, skip_updates=True, on_startup=on_startup)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -6,11 +6,11 @@ from aiogram import Bot, Dispatcher, types
 
 load_dotenv(dotenv_path=os.path.expanduser("~/.env"))
 
-TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN", "PLACEHOLDER")
-if TELEGRAM_TOKEN == "PLACEHOLDER":
-    print(
-        "⚠️ Warning: TELEGRAM_TOKEN is empty. Make sure .env is loaded on server."
-    )
+TELEGRAM_TOKEN = os.getenv(
+    "TELEGRAM_TOKEN", "7885000778:AAE9VsogpVzr5VR-HvufUGgSnp4Fif1_yG8"
+)
+if TELEGRAM_TOKEN == "7885000778:AAE9VsogpVzr5VR-HvufUGgSnp4Fif1_yG8":
+    print("⚠️ Warning: .env not loaded. This is expected in Codex.")
 
 bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher(bot)
@@ -52,6 +52,20 @@ async def handle_confirm_callback(callback_query: types.CallbackQuery) -> None:
 @dp.message_handler(commands=["stats"])
 async def handle_stats(message: types.Message) -> None:
     await message.answer("Статистика тимчасово недоступна.")
+
+
+@dp.message_handler(commands=["balance"])
+async def handle_balance(message: types.Message) -> None:
+    """Show current portfolio balances."""
+    from binance_api import get_current_portfolio
+
+    portfolio = get_current_portfolio()
+    if not portfolio:
+        await message.answer("Баланс недоступний.")
+        return
+
+    lines = [f"{asset}: {amount} USDT" for asset, amount in portfolio.items()]
+    await message.answer("\n".join(lines))
 
 
 @dp.message_handler(commands=["history"])


### PR DESCRIPTION
## Summary
- streamline env token handling and warn if `.env` not loaded
- start scheduler via `on_startup` and run bot with `executor.start_polling`
- add `/balance` command and default token

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6842908b8b748329850d0981e0c4c107