### PR TITLE
Add logrotate configuration for crypto bot log

### DIFF
--- a/logrotate/crypto-bot
+++ b/logrotate/crypto-bot
@@ -1,9 +1,9 @@
-/root/telegram-crypto-bot-github/daily.log {
+/var/log/crypto-bot.log {
     daily
     rotate 7
-    missingok
-    notifempty
     compress
     delaycompress
+    missingok
+    notifempty
     copytruncate
 }


### PR DESCRIPTION
## Summary
- configure logrotate for `/var/log/crypto-bot.log`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install -r requirements.txt` *(fails: Failed building wheel for aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_684296c58ea483298007a5be5b840537