### PR TITLE
Update systemd service

### DIFF
--- a/systemd/crypto-bot.service
+++ b/systemd/crypto-bot.service
@@ -1,17 +1,16 @@
 [Unit]
-Description=Telegram GPT Crypto Bot
+Description=Telegram Crypto Bot
 After=network.target
 
 [Service]
-User=root
+Type=simple
 WorkingDirectory=/root/telegram-crypto-bot-github
-ExecStart=/usr/bin/python3 /root/telegram-crypto-bot-github/main.py
+ExecStart=/bin/sh -c "[ -x venv/bin/python ] && exec venv/bin/python main.py || exec /usr/bin/python3 main.py"
 Restart=always
 RestartSec=5
-StandardOutput=journal
-StandardError=journal
-Environment=PYTHONUNBUFFERED=1
-EnvironmentFile=/root/.env
+StandardOutput=append:/var/log/crypto-bot.log
+StandardError=append:/var/log/crypto-bot.log
+Environment="PYTHONUNBUFFERED=1"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- configure crypto-bot service to log to `/var/log/crypto-bot.log`
- start the bot from a virtual environment if available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684297902e9c83298b98d2792ee49b87