### PR TITLE
Add simple restart helper script

### DIFF
--- a/restart_bot.sh
+++ b/restart_bot.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-export $(grep -v '^#' /root/.env | xargs)
-
-
-echo "🔁 Перезапуск Telegram GPT-бота..."
-sudo systemctl restart crypto-bot
-sudo systemctl status crypto-bot --no-pager
+echo "🔁 Перезапуск Telegram GPT Bot..."
+sudo systemctl restart crypto-bot.service
+echo "✅ Готово!"


### PR DESCRIPTION
## Summary
- simplify `restart_bot.sh` for quick manual restarts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6842b088ec70832988afd8e4fc8f148c