### PR TITLE
Add manual Binance API testing script

### DIFF
--- a/test_binance.py
+++ b/test_binance.py
@@ -1,22 +1,33 @@
-from dotenv import load_dotenv
-from binance.client import Client
-from binance.exceptions import BinanceAPIException
-import os
+from binance_api import (
+    get_usdt_balance,
+    get_token_balance,
+    get_symbol_price,
+    place_market_order,
+)
 
-load_dotenv(dotenv_path=os.path.expanduser("~/.env"))
 
-api_key = os.getenv("BINANCE_API_KEY", "")
-api_secret = os.getenv("BINANCE_SECRET_KEY", "")
+def test_balance() -> None:
+    """Print available balances for USDT, BTC and ETH."""
+    print("\U0001F4BC USDT Balance:", get_usdt_balance())
+    print("\U0001F4BC BTC Balance:", get_token_balance("BTC"))
+    print("\U0001F4BC ETH Balance:", get_token_balance("ETH"))
 
-if not api_key or not api_secret:
-    print("BINANCE credentials not provided")
-    exit()
 
-client = Client(api_key=api_key, api_secret=api_secret)
+def test_price() -> None:
+    """Print current prices for BTC and ETH."""
+    print("\U0001F4C8 BTC Price:", get_symbol_price("BTC"))
+    print("\U0001F4C8 ETH Price:", get_symbol_price("ETH"))
 
-try:
-    info = client.get_account()
-    print("✅ Binance access works")
-    print(info)
-except BinanceAPIException as e:
-    print(f"❌ Binance API error: {e}")
+
+def test_order() -> None:
+    """Show how to place a market order (disabled by default)."""
+    print("\U0001F501 [!!!] \u041E\u0440\u0434\u0435\u0440 \u041D\u0415 \u043D\u0430\u0434\u0441\u0438\u043B\u0430\u0454\u0442\u044C\u0441\u044F \u0430\u0432\u0442\u043E\u043C\u0430\u0442\u0438\u0447\u043D\u043E.")
+    print("\U0001F6D1 \u0420\u043E\u0437\u043A\u043E\u043C\u0435\u043D\u0442\u0443\u0439\u0442\u0435, \u0449\u043E\u0431 \u0437\u0430\u043F\u0443\u0441\u0442\u0438\u0442\u0438 \u0440\u0435\u0430\u043B\u044C\u043D\u0438\u0439 \u043E\u0440\u0434\u0435\u0440.")
+    # place_market_order("BTC", "BUY", quantity=0.001)
+
+
+if __name__ == "__main__":
+    print("\U0001F50D \u0422\u0435\u0441\u0442 Binance API\n")
+    test_balance()
+    test_price()
+    # test_order()


### PR DESCRIPTION
## Summary
- replace `test_binance.py` with a small manual testing helper

## Testing
- `python -m py_compile test_binance.py`

------
https://chatgpt.com/codex/tasks/task_e_6842ba6b41f0832983c999a77df7258b