### PR TITLE
Add alerts and stats modules

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -1,0 +1,50 @@
+import json
+import os
+import logging
+from datetime import datetime, timedelta
+from typing import List, Dict
+
+logger = logging.getLogger(__name__)
+ALERTS_FILE = os.getenv("ALERTS_FILE", "pending_alerts.json")
+
+
+def _load_alerts() -> List[Dict]:
+    if os.path.exists(ALERTS_FILE):
+        try:
+            with open(ALERTS_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception as exc:
+            logger.error("Failed to read alerts: %s", exc)
+    return []
+
+
+def _save_alerts(alerts: List[Dict]) -> None:
+    try:
+        with open(ALERTS_FILE, "w", encoding="utf-8") as f:
+            json.dump(alerts, f, ensure_ascii=False, indent=2)
+    except Exception as exc:
+        logger.error("Failed to save alerts: %s", exc)
+
+
+def record_forecast(tokens: List[str]) -> None:
+    alerts = _load_alerts()
+    alerts.append({"tokens": tokens, "timestamp": datetime.utcnow().isoformat(), "done": False})
+    _save_alerts(alerts)
+
+
+async def check_daily_alerts(bot, chat_id: int) -> None:
+    alerts = _load_alerts()
+    now = datetime.utcnow()
+    updated = False
+    for alert in alerts:
+        if not alert.get("done") and datetime.fromisoformat(alert["timestamp"]) < now - timedelta(days=1):
+            try:
+                tokens = ", ".join(alert.get("tokens", []))
+                await bot.send_message(chat_id, f"\u23F0 \u041D\u0430\u0433\u0430\u0434\u0443\u0454\u043C\u043E: {tokens} \u0431\u0435\u0437 \u0434\u0456\u0439")
+                alert["done"] = True
+                updated = True
+            except Exception as exc:  # pragma: no cover - network call
+                logger.error("Failed to send alert: %s", exc)
+    if updated:
+        _save_alerts(alerts)
+

--- a/coingecko_api.py
+++ b/coingecko_api.py
@@ -1,0 +1,32 @@
+import logging
+import requests
+from typing import Optional, Dict
+
+BASE_URL = "https://api.coingecko.com/api/v3"
+logger = logging.getLogger(__name__)
+
+
+def get_coin_market_data(coin_id: str) -> Optional[Dict]:
+    url = f"{BASE_URL}/coins/{coin_id}"
+    params = {
+        "localization": "false",
+        "tickers": "false",
+        "market_data": "true",
+        "community_data": "false",
+        "developer_data": "false",
+        "sparkline": "false",
+    }
+    try:
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json().get("market_data", {})
+        return {
+            "volume_24h": data.get("total_volume", {}).get("usd"),
+            "change_24h": data.get("price_change_percentage_24h"),
+            "sentiment_up": resp.json().get("sentiment_votes_up_percentage"),
+            "sentiment_down": resp.json().get("sentiment_votes_down_percentage"),
+        }
+    except Exception as exc:
+        logger.error("CoinGecko request failed for %s: %s", coin_id, exc)
+        return None
+

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -1,0 +1,37 @@
+import os
+import time
+import logging
+from typing import List, Dict
+
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+logger = logging.getLogger(__name__)
+
+
+def call_chat_completion(messages: List[Dict[str, str]], model: str = "gpt-4", retries: int = 3, delay: float = 2.0) -> str:
+    """Call OpenAI chat completion with basic retry logic."""
+    for attempt in range(retries):
+        try:
+            response = openai.ChatCompletion.create(model=model, messages=messages)
+            return response["choices"][0]["message"]["content"].strip()
+        except Exception as exc:  # pragma: no cover - network call
+            logger.warning("GPT error on attempt %s: %s", attempt + 1, exc)
+            if attempt < retries - 1:
+                time.sleep(delay * (attempt + 1))
+            else:
+                logger.error("GPT failed after %s attempts: %s", retries, exc)
+                return f"[GPT Error] {exc}"
+
+
+def generate_investor_summary(balance: List[str], sells: List[str], buys: List[str]) -> str:
+    """Create investor summary message via GPT."""
+    prompt = (
+        "\u0421\u0444\u043e\u0440\u043c\u0443\u0439 \u043a\u043e\u0440\u043e\u0442\u043a\u0438\u0439 \u0456\u043d\u0432\u0435\u0441\u0442\u043e\u0440\u0441\u044c\u043a\u0438\u0439 \u043f\u0440\u043e\u0433\u043d\u043e\u0437 \u043d\u0430 \u043e\u0441\u043d\u043e\u0432\u0456:\n\n"
+        f"\u0411\u0430\u043b\u0430\u043d\u0441:\n{balance}\n\n"
+        f"\u041f\u0440\u043e\u0434\u0430\u0442\u0438:\n{sells}\n\n"
+        f"\u041a\u0443\u043f\u0438\u0442\u0438:\n{buys}\n"
+    )
+    messages = [{"role": "user", "content": prompt}]
+    return call_chat_completion(messages)
+

--- a/history.py
+++ b/history.py
@@ -1,0 +1,53 @@
+import json
+import os
+import logging
+from datetime import datetime
+from typing import List, Dict
+
+logger = logging.getLogger(__name__)
+HISTORY_FILE = os.getenv("HISTORY_FILE", "trade_history.json")
+
+
+def _load_history() -> List[Dict]:
+    if os.path.exists(HISTORY_FILE):
+        try:
+            with open(HISTORY_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception as exc:
+            logger.error("Failed to read history: %s", exc)
+    return []
+
+
+def _save_history(data: List[Dict]) -> None:
+    try:
+        with open(HISTORY_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+    except Exception as exc:
+        logger.error("Failed to save history: %s", exc)
+
+
+def add_trade(symbol: str, side: str, qty: float, price: float, timestamp: str | None = None) -> None:
+    history = _load_history()
+    history.append(
+        {
+            "symbol": symbol,
+            "side": side,
+            "qty": qty,
+            "price": price,
+            "timestamp": timestamp or datetime.utcnow().isoformat(),
+        }
+    )
+    _save_history(history)
+
+
+def generate_history_report() -> str:
+    history = _load_history()
+    if not history:
+        return "\u041d\u0435\u043c\u0430\u0454 \u0456\u0441\u0442\u043e\u0440\u0456\u0457 \u0443\u0433\u043e\u0434."
+
+    lines = []
+    for item in history:
+        dt = item["timestamp"].split("T")[0]
+        lines.append(f"{dt} {item['symbol']} {item['side']} {item['qty']} @ {item['price']}")
+    return "\U0001F4C3 \u0406\u0441\u0442\u043E\u0440\u0456\u044F \u0443\u0433\u043E\u0434:\n" + "\n".join(lines)
+

--- a/main.py
+++ b/main.py
@@ -3,10 +3,10 @@ import os
 from aiogram import Bot, Dispatcher, types, executor
 from daily_analysis import (
     generate_zarobyty_report,
-    generate_history_report,
-    generate_stats_report,
     generate_daily_stats_report,
 )
+from history import generate_history_report
+from stats import generate_stats_report
 from binance_api import place_market_order
 
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")

--- a/stats.py
+++ b/stats.py
@@ -1,0 +1,41 @@
+import logging
+from datetime import datetime, timedelta
+from typing import List, Dict
+
+from binance_api import get_usdt_to_uah_rate
+from history import _load_history
+
+logger = logging.getLogger(__name__)
+
+
+def _filter_trades(days: int) -> List[Dict]:
+    history = _load_history()
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    return [t for t in history if datetime.fromisoformat(t["timestamp"]) >= cutoff]
+
+
+def _calculate_profit(trades: List[Dict]) -> float:
+    last_buy = {}
+    profit = 0.0
+    for t in trades:
+        symbol = t["symbol"]
+        price = float(t["price"])
+        qty = float(t["qty"])
+        if t["side"].upper() == "BUY":
+            last_buy[symbol] = price
+        elif t["side"].upper() == "SELL" and symbol in last_buy:
+            profit += (price - last_buy[symbol]) * qty
+            last_buy[symbol] = price
+    return profit
+
+
+def generate_stats_report() -> str:
+    week_profit = _calculate_profit(_filter_trades(7))
+    month_profit = _calculate_profit(_filter_trades(30))
+    rate = get_usdt_to_uah_rate()
+    report = (
+        f"\U0001F4C8 \u041F\u0440\u0438\u0431\u0443\u0442\u043E\u043A \u0437\u0430 \u0442\u0438\u0436\u0434\u0435\u043D\u044C: {week_profit:.2f} USDT (~{week_profit * rate:.2f}\u20b4)\n"
+        f"\U0001F4C8 \u041F\u0440\u0438\u0431\u0443\u0442\u043E\u043A \u0437\u0430 \u043C\u0456\u0441\u044F\u0446\u044C: {month_profit:.2f} USDT (~{month_profit * rate:.2f}\u20b4)"
+    )
+    return report
+


### PR DESCRIPTION
## Summary
- add GPT helper with retry logic
- add trade history tracking
- compute weekly and monthly stats
- notify about missed actions
- fetch market data from CoinGecko
- use new helpers from `daily_analysis` and `main`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Failed building wheel for aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_6842e9c244748329a20fec170aacade0