### PR TITLE
Add docstrings and improve helper modules

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -1,3 +1,5 @@
+"""Utilities for storing and checking pending trading alerts."""
+
 import json
 import os
 import logging

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -1,3 +1,5 @@
+"""Wrapper functions for communicating with the OpenAI API."""
+
 import os
 import time
 import logging
@@ -37,7 +39,15 @@ def generate_investor_summary(balance: List[str], sells: List[str], buys: List[s
 
 
 
-def generate_gpt_summary(prompt: str) -> str:
-    """Generate short GPT summary from provided text."""
+def generate_gpt_summary(balance: List[str], sells: List[str], buys: List[str]) -> str:
+    """Generate short GPT summary based on balance and planned trades."""
+    prompt = (
+        "\u0421\u0442\u0432\u043E\u0440\u0438 \u043A\u043E\u0440\u043E\u0442\u043A\u0438\u0439 "
+        "\u043F\u0456\u0434\u0441\u0443\u043C\u043E\u043A \u0434\u043B\u044F \u0456\u043D\u0432\u0435\u0441\u0442\u043E\u0440\u0430 "
+        "\u0437\u0430 \u0434\u0430\u043D\u0438\u043C\u0438:\n\n"
+        f"\u0411\u0430\u043B\u0430\u043D\u0441:\n{balance}\n\n"
+        f"\u041F\u0440\u043E\u0434\u0430\u0442\u0438:\n{sells}\n\n"
+        f"\u041A\u0443\u043F\u0438\u0442\u0438:\n{buys}\n"
+    )
     messages = [{"role": "user", "content": prompt}]
     return call_chat_completion(messages)

--- a/history.py
+++ b/history.py
@@ -1,3 +1,5 @@
+"""Simple storage helpers for keeping trade history."""
+
 import json
 import os
 import logging
@@ -53,6 +55,10 @@ def generate_history_report() -> str:
 
 
 
-def get_trade_history() -> List[Dict]:
-    """Return raw trade history list for /history command."""
-    return _load_history()
+def get_trade_history() -> str:
+    """Return formatted trade history for the /history command."""
+    try:
+        return generate_history_report()
+    except Exception as exc:
+        logger.error("Failed to prepare trade history: %s", exc)
+        return "History unavailable."

--- a/stats.py
+++ b/stats.py
@@ -1,3 +1,5 @@
+"""Helpers for calculating profit statistics for the bot."""
+
 import logging
 from datetime import datetime, timedelta
 from typing import List, Dict
@@ -41,8 +43,15 @@ def generate_stats_report() -> str:
 
 
 
-def calculate_stats() -> Dict[str, float]:
-    """Return profit statistics for use in /stats command."""
+def calculate_stats() -> str:
+    """Return day, week and month profit summary for Telegram."""
+    day = _calculate_profit(_filter_trades(1))
     week = _calculate_profit(_filter_trades(7))
     month = _calculate_profit(_filter_trades(30))
-    return {"week_profit": week, "month_profit": month}
+    rate = get_usdt_to_uah_rate()
+    return (
+        "\U0001F4C8 \u041F\u0456\u0434\u0441\u0443\u043C\u043E\u043A:\n"
+        f"\u0414\u0435\u043D\u044C: {day:.2f} USDT (~{day * rate:.2f}\u20B4)\n"
+        f"\u0422\u0438\u0436\u0434\u0435\u043D\u044C: {week:.2f} USDT (~{week * rate:.2f}\u20B4)\n"
+        f"\u041C\u0456\u0441\u044F\u0446\u044C: {month:.2f} USDT (~{month * rate:.2f}\u20B4)"
+    )


### PR DESCRIPTION
## Summary
- add module documentation strings
- adjust stats reporting and history formatting
- tweak GPT summary helper
- simplify CoinGecko API wrappers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6842eefb867c832998da6b467cae5968