### PR TITLE
Fix Binance client init

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -24,13 +24,14 @@ if not BINANCE_API_KEY or not BINANCE_SECRET_KEY:
 BINANCE_BASE_URL = "https://api.binance.com"
 
 # 🧩 Ініціалізація клієнта Binance
-# ping=False запобігає зверненню до API під час ініціалізації, що
-# важливо для середовищ без інтернет-доступу
 client = Client(
     api_key=BINANCE_API_KEY,
     api_secret=BINANCE_SECRET_KEY,
-    ping=False,
 )
+try:
+    client.ping()
+except Exception as exc:  # pragma: no cover - network call
+    logger.debug(f"{TELEGRAM_LOG_PREFIX} Ping failed: {exc}")
 # 🕒 Отримання поточного timestamp для підпису запитів
 def get_timestamp() -> int:
     return int(time.time() * 1000)


### PR DESCRIPTION
## Summary
- drop unsupported `ping` option from `Client`
- handle optional connection ping explicitly after client init

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6842f0e8a1d4832991d5145b5c03a047