### PR TITLE
Refactor telegram bot init

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,17 +1,15 @@
-import asyncio
 import logging
-
+from aiogram import Bot, Dispatcher, types, executor
 from telegram_bot import dp, bot, setup_scheduler
 
 
 logging.basicConfig(level=logging.INFO)
 
 
-async def main() -> None:
+async def on_startup(dispatcher: Dispatcher) -> None:
     setup_scheduler()
     await bot.delete_webhook(drop_pending_updates=True)
-    await dp.start_polling(bot)
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    executor.start_polling(dp, on_startup=on_startup)


### PR DESCRIPTION
## Summary
- simplify aiogram initialization
- remove `Router` usage
- call `executor.start_polling`

## Testing
- `python -m py_compile main.py telegram_bot.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68430a93f4b08329a7126e79676b14f7