### PR TITLE
Fix rounding in Binance balances

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -119,7 +119,10 @@ def get_binance_balances() -> Dict[str, Dict[str, float]]:
             if free > 0:
                 symbol = asset + "USDT"
                 usdt_value = free * price_map.get(symbol, 0)
-                balances[asset] = {"free": free, "usdtValue": round(usdt_value, 2)}
+                balances[asset] = {
+                    "free": round(free, 6),
+                    "usdtValue": round(usdt_value, 2),
+                }
         return balances
     finally:
         try:


### PR DESCRIPTION
## Summary
- round free asset amounts in `get_binance_balances`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843234afd9483298a8303ee594feb43