### PR TITLE
Fix aiogram dependency and clean import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-binance>=1.0.17
 openai>=1.14.2
-aiogram>=3.4.1
+aiogram>=2.25,<3
 requests>=2.31.0
 APScheduler>=3.10.4
 python-dotenv>=1.0.1

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -4,7 +4,6 @@ import os
 import logging
 from aiogram import Bot, Dispatcher, types
 from aiogram.dispatcher.filters import Command
-from aiogram.utils import executor
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from daily_analysis import (


### PR DESCRIPTION
## Summary
- use aiogram 2.x in requirements
- clean up unused executor import

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68432b8262f08329b45fc7fc5db48497