### PR TITLE
Update service to load env from system path

### DIFF
--- a/systemd/crypto-bot.service
+++ b/systemd/crypto-bot.service
@@ -12,6 +12,7 @@ StandardOutput=journal
 StandardError=journal
 Environment=PYTHONUNBUFFERED=1
 EnvironmentFile=/root/telegram-crypto-bot-github/.env
+EnvironmentFile=/etc/systemd/system/crypto-bot.env
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- load system credentials from `/etc/systemd/system/crypto-bot.env`

## Testing
- `pip install python-binance openai aiogram requests APScheduler python-dotenv pytz`
- `pytest -q` *(fails: Binance API not accessible)*

------
https://chatgpt.com/codex/tasks/task_e_6843434d7b348329bafac3c409bd29e0