### PR TITLE
Update crypto-bot service env configuration

### DIFF
--- a/systemd/crypto-bot.service
+++ b/systemd/crypto-bot.service
@@ -11,8 +11,8 @@ RestartSec=5
 StandardOutput=journal
 StandardError=journal
 Environment=PYTHONUNBUFFERED=1
-EnvironmentFile=/root/telegram-crypto-bot-github/.env
-EnvironmentFile=/etc/systemd/system/crypto-bot.env
+Environment=BINANCE_API_KEY=SwG2AFeVJ2pv11Q6WHiaceQGm5815Qqzj5GNgbv36pPnvvfZuYuMCg6lWAC37jfX
+Environment=BINANCE_SECRET_KEY=LdEqOMTXMgzsQrU5wUU47kt39VtNhPfykAApUfozgeHIYz2T0lYzzDK4kUuCX7UQ
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- inline API credentials in `systemd/crypto-bot.service`
- remove old EnvironmentFile references

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684344f691088329a1ebbbe470bcd4b9