### PR TITLE
Update crypto service configuration

### DIFF
--- a/systemd/crypto-bot.service
+++ b/systemd/crypto-bot.service
@@ -11,8 +11,7 @@ RestartSec=5
 StandardOutput=journal
 StandardError=journal
 Environment=PYTHONUNBUFFERED=1
-Environment=BINANCE_API_KEY=SwG2AFeVJ2pv11Q6WHiaceQGm5815Qqzj5GNgbv36pPnvvfZuYuMCg6lWAC37jfX
-Environment=BINANCE_SECRET_KEY=LdEqOMTXMgzsQrU5wUU47kt39VtNhPfykAApUfozgeHIYz2T0lYzzDK4kUuCX7UQ
+EnvironmentFile=/etc/crypto-bot.env
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- refresh systemd unit to source env vars from `/etc/crypto-bot.env`
- ensure the environment file exists on the system

## Testing
- `pip install -r requirements.txt` *(fails: Failed to build installable wheels)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684345dcd884832992f51f9514c02b37