### PR TITLE
Update keyboard buttons for zarobyty report

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -31,6 +31,7 @@ def generate_zarobyty_report() -> Tuple[str, InlineKeyboardMarkup]:
     sell_recommendations = []
     buy_recommendations = []
     expected_profit = 0.0
+    buttons = []
     keyboard = InlineKeyboardMarkup(row_width=2)
 
     for token in tokens:
@@ -45,22 +46,25 @@ def generate_zarobyty_report() -> Tuple[str, InlineKeyboardMarkup]:
             sell_recommendations.append(
                 f"\U0001f534 {token} ({percent_change}%)"
             )
-            keyboard.insert(
+            buttons.append(
                 InlineKeyboardButton(
-                    f"Sell {token}", callback_data=f"confirmsell_{token}"
+                    text=f"\U0001F534 \u041F\u0440\u043E\u0434\u0430\u0442\u0438 {token}",
+                    callback_data=f"confirmsell_{token}"
                 )
             )
         elif percent_change > 1.0:
             buy_recommendations.append(
                 f"\U0001f7e2 {token} ({percent_change}%)"
             )
-            keyboard.insert(
+            buttons.append(
                 InlineKeyboardButton(
-                    f"Buy {token}", callback_data=f"confirmbuy_{token}"
+                    text=f"\U0001F7E2 \u041A\u0443\u043F\u0438\u0442\u0438 {token}",
+                    callback_data=f"confirmbuy_{token}"
                 )
             )
             expected_profit += round(amount * price * 0.02, 2)
 
+    keyboard.add(*buttons)
     gpt_summary = call_gpt_summary(balances, sell_recommendations, buy_recommendations)
 
     # record tokens for alert if user doesn't act


### PR DESCRIPTION
## Summary
- switch to inline buttons for buy/sell confirmations in `generate_zarobyty_report`
- build the keyboard using `InlineKeyboardMarkup(row_width=2)` and add the new buttons

## Testing
- `pip install -r requirements.txt` *(fails: aiohttp build errors)*
- `pytest -q` *(fails: Binance API error due to restricted location)*

------
https://chatgpt.com/codex/tasks/task_e_6843cb0bc1548329a8a51870a75030e2