### PR TITLE
Register bot handlers on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,16 +1,17 @@
 import logging
 from aiogram import Bot, Dispatcher, types
 from aiogram.utils import executor
-from telegram_bot import dp, bot, setup_scheduler
+from telegram_bot import dp, bot, setup_scheduler, register_handlers
 
 
 logging.basicConfig(level=logging.INFO)
 
 
 async def on_startup(dispatcher: Dispatcher) -> None:
-    setup_scheduler()
     await bot.delete_webhook(drop_pending_updates=True)
 
 
 if __name__ == "__main__":
+    setup_scheduler()
+    register_handlers(dp)
     executor.start_polling(dp, on_startup=on_startup)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -106,3 +106,20 @@ def setup_scheduler() -> None:
     )
     scheduler.start()
 
+
+def register_handlers(dp: Dispatcher) -> None:
+    """Explicitly register all bot handlers."""
+    dp.register_message_handler(start_cmd, commands=["start"])
+    dp.register_message_handler(zarobyty_cmd, Command("zarobyty"))
+    dp.register_callback_query_handler(
+        confirm_buy, lambda c: c.data and c.data.startswith("confirmbuy_")
+    )
+    dp.register_callback_query_handler(
+        confirm_sell, lambda c: c.data and c.data.startswith("confirmsell_")
+    )
+    dp.register_message_handler(history_cmd, commands=["history"])
+    dp.register_message_handler(stats_cmd, commands=["stats"])
+    dp.register_message_handler(statsday_cmd, commands=["statsday"])
+    dp.register_message_handler(price24_cmd, commands=["price24"])
+    dp.register_message_handler(alerts_on_cmd, commands=["alerts_on"])
+


### PR DESCRIPTION
## Summary
- add `register_handlers` function to collect all handlers
- adjust `main.py` to import and invoke `register_handlers`
- update `on_startup` since scheduler is now setup before polling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6843d4cfb7ec8329baf9579ede2f11d7