### PR TITLE
Refactor Telegram handlers into register function

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
 import logging
-from aiogram import Bot, Dispatcher, types
+from aiogram import Dispatcher
 from aiogram.utils import executor
-from telegram_bot import dp, bot, setup_scheduler, register_handlers
+from telegram_bot import bot, setup_scheduler, register_handlers
+
+dp = Dispatcher(bot)
 
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- centralize telegram handlers into `register_handlers`
- update main entrypoint to create dispatcher

## Testing
- `python -m py_compile telegram_bot.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6843dc18f434832997f3c4a7dc7b9924