### PR TITLE
Fix telegram handler registration

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,7 @@
 import logging
 from aiogram import Dispatcher
 from aiogram.utils import executor
-from telegram_bot import bot, setup_scheduler, register_handlers
-
-dp = Dispatcher(bot)
-
+from telegram_bot import dp, bot, setup_scheduler, register_handlers
 
 logging.basicConfig(level=logging.INFO)
 

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -20,6 +20,7 @@ TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 ADMIN_CHAT_ID = int(os.getenv("ADMIN_CHAT_ID", os.getenv("CHAT_ID", "0")))
 
 bot = Bot(token=TELEGRAM_TOKEN)
+dp = Dispatcher(bot)
 
 scheduler = AsyncIOScheduler(timezone="UTC")
 


### PR DESCRIPTION
## Summary
- expose `dp` object from `telegram_bot`
- import dispatcher from `telegram_bot` in `main.py`
- register handlers before starting polling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6843e53ff8dc83298bc6cfced9631d8b