### PR TITLE
Fix ZeroDivisionError by skipping USDT in price loop

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -68,6 +68,8 @@ def generate_zarobyty_report() -> Tuple[str, InlineKeyboardMarkup]:
 
     for token in tokens:
         amount = get_token_balance(token)
+        if token == "USDT":
+            continue
         price = get_symbol_price(token)
         uah_value = round(amount * price * UAH_RATE, 2)
         percent_change = round((price - price * 0.98) / price * 100, 2)


### PR DESCRIPTION
## Summary
- skip USDT in the recommendation loop so that it isn't priced

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684413ea889883298d42d80a9e221491