### PR TITLE
Fix price API call in daily report

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -7,7 +7,7 @@ import statistics
 
 from binance_api import (
     get_binance_balances,
-    get_token_price,
+    get_symbol_price,
     get_price_history,
     get_klines,
     get_my_trades,
@@ -29,7 +29,7 @@ def generate_zarobyty_report():
         if symbol == "USDT" or amount == 0:
             continue
 
-        price = get_token_price(symbol)
+        price = get_symbol_price(symbol)
         uah_value = convert_to_uah(price * amount)
         price_history = get_price_history(symbol)
         klines = get_klines(symbol)
@@ -64,7 +64,7 @@ def generate_zarobyty_report():
 
     buy_candidates = []
     for symbol in symbols_to_analyze:
-        price = get_token_price(symbol)
+        price = get_symbol_price(symbol)
         klines = get_klines(symbol)
         indicators = calculate_indicators(klines)
         rr = calculate_rr(klines)


### PR DESCRIPTION
## Summary
- update import to `get_symbol_price`
- call `get_symbol_price` throughout `daily_analysis.py`

## Testing
- `python -m pytest -q` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68453d957a4c8329a8837936aff9e59a