### PR TITLE
Fix price history import in daily analysis

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -8,7 +8,7 @@ import statistics
 from binance_api import (
     get_binance_balances,
     get_symbol_price,
-    get_price_history,
+    get_price_history_24h as get_price_history,
     get_klines,
     get_my_trades,
     get_top_tokens,


### PR DESCRIPTION
## Summary
- use `get_price_history_24h` via alias in `daily_analysis.py`

## Testing
- `python -m py_compile daily_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_68453ed99cec83299249c9d55b4a056d