### PR TITLE
Fix import path in daily_analysis

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -13,7 +13,7 @@ from binance_api import (
     get_recent_trades as get_my_trades,
     get_top_tokens,
 )
-from gpt import ask_gpt
+from gpt_utils import ask_gpt
 from utils import convert_to_uah, calculate_rr, calculate_indicators, get_sector, analyze_btc_correlation
 from keyboards import zarobyty_keyboard
 


### PR DESCRIPTION
## Summary
- update GPT import path in `daily_analysis.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: Failed building wheel for aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_684542778c3c8329acebb1c3537f0d65