### PR TITLE
Fix indicator input validation and use OHLCV klines

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -376,6 +376,19 @@ def get_price_history_24h(symbol: str) -> Optional[List[float]]:
         return None
 
 
+def get_candlestick_klines(symbol: str, interval: str = "1h", limit: int = 100) -> List[List[float]]:
+    """Return raw candlestick klines for a symbol."""
+    url = f"{BINANCE_BASE_URL}/api/v3/klines"
+    params = {"symbol": f"{symbol.upper()}USDT", "interval": interval, "limit": limit}
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except Exception as e:  # pragma: no cover - network errors
+        logger.warning("❌ Klines error for %s: %s", symbol, e)
+        return []
+
+
 def get_recent_trades(symbol: str = "BTCUSDT", limit: int = 5) -> List[Dict[str, object]]:
     """Return recent trades from Binance."""
 

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -9,7 +9,7 @@ from binance_api import (
     get_binance_balances,
     get_symbol_price,
     get_price_history_24h as get_price_history,
-    get_price_history_24h as get_klines,
+    get_candlestick_klines as get_klines,
     get_recent_trades as get_my_trades,
     get_top_tokens,
 )

--- a/utils.py
+++ b/utils.py
@@ -40,6 +40,11 @@ def _ema(values: List[float], period: int) -> List[float]:
 
 def calculate_indicators(klines: List[List[float]]) -> Dict[str, float]:
     """Calculate basic indicators for token."""
+    if not klines or not isinstance(klines[0], (list, tuple)):
+        raise TypeError(
+            f"❌ Неправильний формат klines: {type(klines[0])}, очікується список OHLCV"
+        )
+
     closes = [float(k[4]) for k in klines]
 
     ema5 = _ema(closes, 5)[-1] if closes else 0.0


### PR DESCRIPTION
## Summary
- validate format of `klines` in `calculate_indicators`
- expose `get_candlestick_klines` helper in `binance_api`
- use the new klines API inside `daily_analysis`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError / missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68466ee290408329853d6098cb91b45a