### PR TITLE
fix: simplify USDT balance retrieval

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -26,14 +26,7 @@ logger = logging.getLogger(__name__)
 
 def generate_zarobyty_report():
     balances = get_binance_balances()
-    usdt_info = balances.get("USDT", {})
-    usdt_balance = (
-        usdt_info["free"]
-        if isinstance(usdt_info, dict) and "free" in usdt_info
-        else usdt_info
-        if isinstance(usdt_info, (int, float))
-        else 0.0
-    )
+    usdt_balance = balances.get("USDT", 0)
     if usdt_balance is None:
         usdt_balance = 0
 


### PR DESCRIPTION
## Summary
- simplify how USDT balance is read in `daily_analysis.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6846bff39474832997581845c7cd9cc3