### PR TITLE
Handle missing zarobyty report

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -83,9 +83,18 @@ def register_handlers(dp: Dispatcher) -> None:
 
     async def zarobyty_cmd(message: types.Message) -> None:
         report, keyboard = generate_zarobyty_report()
+        if not report:
+            await message.answer(
+                "⚠️ Звіт наразі недоступний. Спробуйте пізніше."
+            )
+            return
         logger.info("Zarobyty report:\n%s", report)
+        print("✅ Звіт сформовано:", report[:200])
         report = clean_surrogates(report)
-        await message.answer(report, parse_mode="Markdown", reply_markup=keyboard)
+        if keyboard is None:
+            await message.answer(report, parse_mode="Markdown")
+        else:
+            await message.answer(report, parse_mode="Markdown", reply_markup=keyboard)
 
     async def confirm_buy(callback_query: types.CallbackQuery) -> None:
         token = callback_query.data.replace("confirmbuy_", "")


### PR DESCRIPTION
## Summary
- send a fallback message when zarobyty report is empty
- log a short preview of the report before sending
- allow sending report without a keyboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6846c4d2fccc83299e1d9575879d87ce