### PR TITLE
Implement take profit stop-limit feature

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -214,6 +214,17 @@ def get_symbol_price(symbol: str) -> float:
         return 0.0
 
 
+def get_token_price(symbol: str) -> dict:
+    """Return token price with symbol."""
+
+    try:
+        ticker = client.get_symbol_ticker(symbol=f"{symbol.upper()}USDT")
+        return {"symbol": symbol.upper(), "price": ticker.get("price", "0")}
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("%s Помилка при отриманні ціни %s: %s", TELEGRAM_LOG_PREFIX, symbol, exc)
+        return {"symbol": symbol.upper(), "price": "0"}
+
+
 def place_market_order(symbol: str, side: str, quantity: float) -> Optional[Dict[str, object]]:
     """Execute a market order to buy or sell."""
 
@@ -266,6 +277,32 @@ def create_take_profit_order(symbol: str, quantity: float, target_price: float) 
         return {"success": True, "order": order}
     except Exception as e:  # pragma: no cover - network errors
         return {"success": False, "error": str(e)}
+
+
+def place_stop_limit_sell_order(
+    symbol: str, quantity: float, stop_price: float, limit_price: float
+) -> dict:
+    """Create STOP_LIMIT SELL order on Binance."""
+
+    try:
+        order = client.create_order(
+            symbol=f"{symbol.upper()}USDT",
+            side="SELL",
+            type="STOP_LOSS_LIMIT",
+            timeInForce="GTC",
+            quantity=round(quantity, 6),
+            price=str(round(limit_price, 6)),
+            stopPrice=str(round(stop_price, 6)),
+        )
+        return order
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error(
+            "%s Не вдалося створити STOP_LIMIT SELL для %s: %s",
+            TELEGRAM_LOG_PREFIX,
+            symbol,
+            exc,
+        )
+        return {"error": str(exc)}
 
 
 def get_open_orders(symbol: str | None = None) -> list:

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -210,11 +210,10 @@ def generate_zarobyty_report() -> tuple[str, InlineKeyboardMarkup]:
 
     for token in token_data:
         if token['pnl'] > 10:
-            take_profit_price = round(token['price'] * 1.05, 5)
             keyboard.inline_keyboard.append([
                 InlineKeyboardButton(
-                    text=f"🎯 Фіксувати прибуток ({token['symbol']})",
-                    callback_data=f"take_profit:{token['symbol']}:{token['quantity']}:{take_profit_price}"
+                    text=f"📉 Фіксувати прибуток ({token['symbol']})",
+                    callback_data=f"takeprofit_{token['symbol']}"
                 )
             ])
 

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -362,7 +362,7 @@ async def handle_take_profit_callback(callback_query: types.CallbackQuery):
     try:
         price_data = get_token_price(token)
         current_price = float(price_data["price"])
-        target_profit_percent = 10  # фіксація прибутку при +10%
+        target_profit_percent = 10  # Прибуток у %
         take_profit_price = round(current_price * (1 + target_profit_percent / 100), 6)
         balance = get_token_balance(token)
 
@@ -372,11 +372,22 @@ async def handle_take_profit_callback(callback_query: types.CallbackQuery):
             )
             return
 
-        result = place_stop_limit_sell_order(token, balance, take_profit_price)
-        await callback_query.message.answer(
-            f"📉 Ордер на фіксацію прибутку встановлено:\n"
-            f"{balance} {token} при {take_profit_price}"
+        result = place_stop_limit_sell_order(
+            symbol=token,
+            quantity=balance,
+            stop_price=take_profit_price,
+            limit_price=take_profit_price,
         )
+
+        if result.get("orderId"):
+            await callback_query.message.answer(
+                f"📉 Ордер на фіксацію прибутку створено:\n"
+                f"{balance} {token} при {take_profit_price}"
+            )
+        else:
+            await callback_query.message.answer(
+                f"⚠️ Не вдалося створити ордер для {token}.\n{result}"
+            )
     except Exception as e:
         await callback_query.message.answer(
             f"❌ Помилка при створенні take profit для {token}:\n{e}"


### PR DESCRIPTION
## Summary
- add `get_token_price` and `place_stop_limit_sell_order` helpers for Binance API
- show `📉 Фіксувати прибуток` buttons in the daily report
- create a new callback for `takeprofit_` that sets a STOP_LIMIT sell order

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: building wheel for aiohttp)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6846dabc76a8832983081d9d2726ce60