### PR TITLE
Add smart buy callback

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -279,6 +279,32 @@ def create_take_profit_order(symbol: str, quantity: float, target_price: float) 
         return {"success": False, "error": str(e)}
 
 
+def place_stop_limit_buy_order(
+    symbol: str, quantity: float, stop_price: float, limit_price: float
+) -> dict:
+    """Create STOP_LIMIT BUY order on Binance."""
+
+    try:
+        order = client.create_order(
+            symbol=f"{symbol.upper()}USDT",
+            side="BUY",
+            type="STOP_LOSS_LIMIT",
+            timeInForce="GTC",
+            quantity=round(quantity, 6),
+            price=str(round(limit_price, 6)),
+            stopPrice=str(round(stop_price, 6)),
+        )
+        return order
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error(
+            "%s Не вдалося створити STOP_LIMIT BUY для %s: %s",
+            TELEGRAM_LOG_PREFIX,
+            symbol,
+            exc,
+        )
+        return {"error": str(exc)}
+
+
 def place_stop_limit_sell_order(
     symbol: str, quantity: float, stop_price: float, limit_price: float
 ) -> dict:

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -207,6 +207,12 @@ def generate_zarobyty_report() -> tuple[str, InlineKeyboardMarkup]:
                 callback_data=f"buy:{token['symbol']}"
             )
         )
+        keyboard.insert(
+            InlineKeyboardButton(
+                text=f"\U0001F6D2 \u041A\u0443\u043F\u0438\u0442\u0438 {token['symbol']}",
+                callback_data=f"smartbuy_{token['symbol']}"
+            )
+        )
 
     for token in token_data:
         if token['pnl'] > 10:


### PR DESCRIPTION
## Summary
- add `place_stop_limit_buy_order` to Binance API helpers
- expose new order helper and USDT balance to the bot
- implement `/smartbuy` callback handler
- show Smart Buy button in daily report

## Testing
- `pytest -q` *(fails: Binance API blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6846dc4ec1408329ad95bd7e17848c27