### PR TITLE
Add take profit after buying

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -317,6 +317,29 @@ def place_limit_sell(symbol: str, quantity: float) -> dict:
         return {"success": False, "error": str(exc)}
 
 
+def place_limit_sell_order(symbol: str, quantity: float, price: float) -> dict:
+    """Place a LIMIT SELL order at a specific price."""
+    try:
+        order = client.create_order(
+            symbol=symbol.upper(),
+            side="SELL",
+            type="LIMIT",
+            timeInForce="GTC",
+            quantity=round(quantity, 6),
+            price=str(round(price, 6)),
+        )
+        return {"success": True, "order": order}
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error(
+            "%s Failed to place limit sell order for %s at %s: %s",
+            TELEGRAM_LOG_PREFIX,
+            symbol,
+            price,
+            exc,
+        )
+        return {"success": False, "error": str(exc)}
+
+
 def place_take_profit_order(
     symbol: str,
     quantity: float,


### PR DESCRIPTION
## Summary
- add helper for limit sell orders
- auto place take profit limit order after market buy in bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: Service unavailable from Binance)*

------
https://chatgpt.com/codex/tasks/task_e_6846e2596c9c832998951e34d0378a54