### PR TITLE
Add automatic TP after market buy

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -256,12 +256,15 @@ def place_market_order(symbol: str, side: str, usdt_amount: float) -> Optional[D
         logger.info("%s Ордер %s виконано: %s", TELEGRAM_LOG_PREFIX, side, order)
 
         if side.upper() == "BUY" and order.get("status") == "FILLED":
-            executed_price = float(order["fills"][0]["price"])
-            place_take_profit_order(
-                symbol=f"{symbol.upper()}USDT",
-                quantity=quantity,
-                current_price=executed_price,
-            )
+            # Встановлення Take Profit (TP) після покупки
+            executed_qty = float(order.get("executedQty", quantity))
+            if current_price := get_symbol_price(symbol):
+                take_profit_price = round(current_price * 1.10, 5)
+                place_limit_sell_order(
+                    f"{symbol.upper()}USDT",
+                    executed_qty,
+                    take_profit_price,
+                )
 
         return order
 


### PR DESCRIPTION
## Summary
- automatically place limit sell order after executing a market buy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: Failed building wheel for aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_6846e51b10dc83298106bd99cdd99460