### PR TITLE
Add order editing and monitoring

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -517,6 +517,33 @@ def get_open_orders(symbol: str | None = None) -> list:
         return []
 
 
+def cancel_order(order_id: int, symbol: str = "USDTBTC") -> bool:
+    """Cancel an existing order by ID."""
+    try:
+        response = client.cancel_order(symbol=symbol, orderId=order_id)
+        return response.get("status") == "CANCELED"
+    except Exception as e:
+        logger.error("[ERROR] cancel_order: %s", e)
+        return False
+
+
+def update_tp_sl_order(order_id: int, price: float, symbol: str) -> bool:
+    """Update TP/SL order price."""
+    try:
+        client.cancel_order(symbol=symbol, orderId=order_id)
+        client.create_order(
+            symbol=symbol,
+            side=SIDE_SELL,
+            type=ORDER_TYPE_LIMIT,
+            quantity=0,
+            price=str(price),
+        )
+        return True
+    except Exception as e:
+        logger.error("[ERROR] update_tp_sl_order: %s", e)
+        return False
+
+
 def get_usdt_to_uah_rate() -> float:
     """Return USDT to UAH conversion rate."""
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,24 @@
 import logging
+import asyncio
 from aiogram import Dispatcher
 from aiogram.utils import executor
-from telegram_bot import dp, bot, setup_scheduler, register_handlers
+from telegram_bot import dp, bot, setup_scheduler, register_handlers, ADMIN_CHAT_ID
+from binance_api import get_open_orders
 
 logging.basicConfig(level=logging.INFO)
+
+
+async def monitor_orders() -> None:
+    """Periodically check open orders and notify when filled."""
+    while True:
+        open_orders = get_open_orders()
+        for order in open_orders:
+            if order.get("status") == "FILLED":
+                await bot.send_message(
+                    ADMIN_CHAT_ID,
+                    f"\U0001F3AF Ордер виконано: {order['symbol']} {order['side']}",
+                )
+        await asyncio.sleep(30)
 
 
 async def on_startup(dispatcher: Dispatcher) -> None:
@@ -13,4 +28,6 @@ async def on_startup(dispatcher: Dispatcher) -> None:
 if __name__ == "__main__":
     setup_scheduler()
     register_handlers(dp)
+    loop = asyncio.get_event_loop()
+    loop.create_task(monitor_orders())
     executor.start_polling(dp, on_startup=on_startup)


### PR DESCRIPTION
## Summary
- add reply keyboard with **Змінити ордери** option
- implement handlers to cancel open orders and refresh the list
- expose order cancellation helpers in `binance_api`
- monitor orders asynchronously from `main.py`

## Testing
- `python -m py_compile telegram_bot.py binance_api.py main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6846efbb0c58832980c9140894123424