### PR TITLE
Implement TP/SL auto-update logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,14 @@ import logging
 import asyncio
 from aiogram import Dispatcher
 from aiogram.utils import executor
-from telegram_bot import dp, bot, setup_scheduler, register_handlers, ADMIN_CHAT_ID
+from telegram_bot import (
+    dp,
+    bot,
+    setup_scheduler,
+    register_handlers,
+    ADMIN_CHAT_ID,
+    check_tp_sl_execution,
+)
 from binance_api import get_open_orders
 
 logging.basicConfig(level=logging.INFO)
@@ -18,6 +25,7 @@ async def monitor_orders() -> None:
                     ADMIN_CHAT_ID,
                     f"\U0001F3AF Ордер виконано: {order['symbol']} {order['side']}",
                 )
+        await check_tp_sl_execution()
         await asyncio.sleep(30)
 
 


### PR DESCRIPTION
## Summary
- add `update_tp_sl_order` to recreate TP/SL orders with new prices
- check and refresh existing orders in `generate_zarobyty_report`
- send update messages from telegram bot
- track active TP/SL orders and adjust periodically
- monitor open orders and TP/SL updates in main loop

## Testing
- `python -m py_compile binance_api.py daily_analysis.py telegram_bot.py main.py run_daily_analysis.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6846f207bcf083298c03b7a0ea738f69