### PR TITLE
Add TP/SL logging utility

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -13,6 +13,8 @@ import hmac
 import hashlib
 import logging
 import decimal
+import json
+from datetime import datetime
 from typing import Dict, List, Optional
 
 import requests
@@ -34,6 +36,33 @@ TELEGRAM_LOG_PREFIX = "\ud83d\udce1 [BINANCE]"
 BINANCE_API_KEY = os.getenv("BINANCE_API_KEY")
 BINANCE_SECRET_KEY = os.getenv("BINANCE_SECRET_KEY")
 BINANCE_BASE_URL = "https://api.binance.com"
+
+# File used to log TP/SL updates
+LOG_FILE = "tp_sl_log.json"
+
+
+def log_tp_sl_change(symbol: str, action: str, tp: float, sl: float) -> None:
+    """Append TP/SL change information to ``LOG_FILE``."""
+
+    log_data = {
+        "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "symbol": symbol,
+        "action": action,
+        "take_profit": tp,
+        "stop_loss": sl,
+    }
+
+    if os.path.exists(LOG_FILE):
+        with open(LOG_FILE, "r", encoding="utf-8") as f:
+            history = json.load(f)
+    else:
+        history = []
+
+    history.append(log_data)
+
+    with open(LOG_FILE, "w", encoding="utf-8") as f:
+        json.dump(history, f, indent=2)
+
 
 print(f"[DEBUG] API: {BINANCE_API_KEY[:6]}..., SECRET: {BINANCE_SECRET_KEY[:6]}...")
 

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -18,6 +18,7 @@ from binance_api import (
     place_limit_sell_order,
     get_open_orders,
     update_tp_sl_order,
+    log_tp_sl_change,
 )
 from gpt_utils import ask_gpt
 from utils import convert_to_uah, calculate_rr, calculate_indicators, get_sector, analyze_btc_correlation
@@ -54,6 +55,7 @@ def _maybe_update_orders(symbol: str, new_tp: float, new_sl: float) -> bool:
 
     if update_needed:
         update_tp_sl_order(symbol, new_tp, new_sl)
+        log_tp_sl_change(symbol, "updated", new_tp, new_sl)
         return True
     return False
 


### PR DESCRIPTION
## Summary
- log TP/SL updates in `tp_sl_log.json`
- call logging after orders are refreshed

## Testing
- `python -m py_compile binance_api.py daily_analysis.py`
- `pytest -q` *(fails: Binance API unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6846f63086208329a4f9a88cf2658d01