### PR TITLE
Add sell_token_market alias

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -1044,3 +1044,7 @@ def place_stop_loss_order_auto(symbol: str, quantity: float | None = None, stop_
         return response.json()
     except Exception as e:  # pragma: no cover - network errors
         return {"error": str(e)}
+
+# Alias для сумісності з існуючим кодом
+sell_token_market = market_sell
+


### PR DESCRIPTION
## Summary
- add alias `sell_token_market` to reuse `market_sell`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6846fd020c1c83298db95d4d71c9f362