### PR TITLE
Add buy_token_market alias

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -1032,3 +1032,6 @@ def place_stop_loss_order_auto(symbol: str, quantity: float | None = None, stop_
 # Alias для сумісності з існуючим кодом
 sell_token_market = market_sell
 
+# 🔁 Alias для сумісності зі старим кодом
+buy_token_market = market_buy
+


### PR DESCRIPTION
## Summary
- add alias `buy_token_market` for backward compatibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68470483e5448329837d10082187b5f5