### PR TITLE
Update symbol filter for daily analysis

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -897,6 +897,26 @@ def get_all_spot_symbols() -> List[str]:
         return []
 
 
+def get_tradable_usdt_symbols() -> List[str]:
+    """Return list of tradable symbols that have an active USDT pair."""
+
+    try:
+        info = client.get_exchange_info()
+        usdt_pairs = [
+            s.get("symbol")
+            for s in info.get("symbols", [])
+            if s.get("quoteAsset") == "USDT" and s.get("status") == "TRADING"
+        ]
+        return list({s.replace("USDT", "") for s in usdt_pairs})
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.warning(
+            "%s \u041f\u043e\u043c\u0438\u043b\u043a\u0430 \u043f\u0440\u0438 \u043e\u0442\u0440\u0438\u043c\u0430\u043d\u043d\u0456 USDT \u0442\u043e\u043a\u0435\u043d\u0456\u0432: %s",
+            TELEGRAM_LOG_PREFIX,
+            exc,
+        )
+        return []
+
+
 def get_top_tokens(limit: int = 50) -> List[str]:
     """Return top tokens by 24h volume."""
 

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -13,6 +13,7 @@ from binance_api import (
     get_candlestick_klines as get_klines,
     get_recent_trades as get_my_trades,
     get_top_tokens,
+    get_tradable_usdt_symbols,
     get_usdt_to_uah_rate,
     place_market_order,
     place_limit_sell_order,
@@ -141,6 +142,9 @@ def generate_zarobyty_report() -> tuple[str, InlineKeyboardMarkup, list]:
     symbols_from_balance = set(t['symbol'].upper() for t in token_data)
     market_symbols = set(s.upper() for s in get_top_tokens(limit=50))
     symbols_to_analyze = symbols_from_balance.union(market_symbols)
+
+    tradable_symbols = set(s.upper() for s in get_tradable_usdt_symbols())
+    symbols_to_analyze = [s for s in symbols_to_analyze if s in tradable_symbols]
 
     enriched_tokens = []
     for symbol in symbols_to_analyze:


### PR DESCRIPTION
## Summary
- add helper to fetch all tradable USDT symbols from Binance
- filter daily analysis tokens using the tradable list

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m py_compile daily_analysis.py binance_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6847e2026d208329bf08ef915a907057