### PR TITLE
Add zarobyty command to Telegram bot menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from telegram_bot import (
     register_change_tp_sl_handler,
     check_tp_sl_execution,
     check_tp_sl_market_change,
+    set_bot_commands,
     ADMIN_CHAT_ID,
     scheduler,
 )
@@ -43,4 +44,5 @@ if __name__ == "__main__":
     scheduler.add_job(check_tp_sl_market_change, "interval", hours=1)
     loop = asyncio.get_event_loop()
     loop.create_task(monitor_orders())
+    loop.run_until_complete(set_bot_commands(bot))
     executor.start_polling(dp, on_startup=on_startup)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -20,6 +20,7 @@ from aiogram.types import (
     InlineKeyboardMarkup,
     ReplyKeyboardMarkup,
     KeyboardButton,
+    BotCommand,
 )
 from aiogram.utils.callback_data import CallbackData
 from binance_api import (
@@ -63,6 +64,13 @@ ADMIN_CHAT_ID = int(os.getenv("ADMIN_CHAT_ID", os.getenv("CHAT_ID", "0")))
 bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher(bot)
 logger = logging.getLogger(__name__)
+
+
+async def set_bot_commands(bot: Bot) -> None:
+    """Configure available bot commands."""
+
+    commands = [BotCommand("zarobyty", "Отримати щоденний звіт")]
+    await bot.set_my_commands(commands)
 
 # Mapping of symbol to current TP/SL order IDs
 active_orders: dict[str, dict] = {}


### PR DESCRIPTION
## Summary
- introduce `set_bot_commands` to register `/zarobyty`
- call `set_bot_commands` before polling starts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68481700d1f48329992b567e10aa30d6