### PR TITLE
Remove command menu setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from telegram_bot import (
     register_change_tp_sl_handler,
     check_tp_sl_execution,
     check_tp_sl_market_change,
-    set_bot_commands,
     ADMIN_CHAT_ID,
     scheduler,
 )
@@ -44,5 +43,4 @@ if __name__ == "__main__":
     scheduler.add_job(check_tp_sl_market_change, "interval", hours=1)
     loop = asyncio.get_event_loop()
     loop.create_task(monitor_orders())
-    loop.run_until_complete(set_bot_commands(bot))
     executor.start_polling(dp, on_startup=on_startup)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -20,7 +20,6 @@ from aiogram.types import (
     InlineKeyboardMarkup,
     ReplyKeyboardMarkup,
     KeyboardButton,
-    BotCommand,
 )
 from aiogram.utils.callback_data import CallbackData
 from binance_api import (
@@ -64,13 +63,6 @@ ADMIN_CHAT_ID = int(os.getenv("ADMIN_CHAT_ID", os.getenv("CHAT_ID", "0")))
 bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher(bot)
 logger = logging.getLogger(__name__)
-
-
-async def set_bot_commands(bot: Bot) -> None:
-    """Configure available bot commands."""
-
-    commands = [BotCommand("zarobyty", "Отримати щоденний звіт")]
-    await bot.set_my_commands(commands)
 
 # Mapping of symbol to current TP/SL order IDs
 active_orders: dict[str, dict] = {}
@@ -124,7 +116,7 @@ menu.row(
     KeyboardButton("\U0001F4CB Змінити ордери")
 )
 menu.row(
-    KeyboardButton("\U0001F6E0\ufe0f Змінити TP/SL")
+    KeyboardButton("\U0001F9F0 Змінити TP/SL")
 )
 menu.row(
     KeyboardButton("\U0001F4CA Баланс"),


### PR DESCRIPTION
## Summary
- drop BotCommand and set_my_commands usage
- tweak TP/SL menu emoji

## Testing
- `python -m py_compile telegram_bot.py main.py`
- `pytest -q` *(fails: ModuleNotFoundError / API restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6848358dfa7c832985a26f4bb6d22c25