### PR TITLE
Clear Telegram bot commands on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from telegram_bot import (
     check_tp_sl_market_change,
     ADMIN_CHAT_ID,
     scheduler,
+    clear_bot_menu,
 )
 from binance_api import get_open_orders
 
@@ -34,6 +35,7 @@ async def monitor_orders() -> None:
 
 async def on_startup(dispatcher: Dispatcher) -> None:
     await bot.delete_webhook(drop_pending_updates=True)
+    await clear_bot_menu(bot)
 
 
 if __name__ == "__main__":

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -64,6 +64,12 @@ bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher(bot)
 logger = logging.getLogger(__name__)
 
+
+async def clear_bot_menu(bot: Bot) -> None:
+    """Remove any custom bot commands."""
+
+    await bot.delete_my_commands()
+
 # Mapping of symbol to current TP/SL order IDs
 active_orders: dict[str, dict] = {}
 


### PR DESCRIPTION
## Summary
- add helper `clear_bot_menu()` in `telegram_bot.py`
- call new helper from `main.on_startup`

## Testing
- `python -m py_compile telegram_bot.py main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails to build `aiohttp`)*

------
https://chatgpt.com/codex/tasks/task_e_68483c891bb08329a14e75529bc7fa87