### PR TITLE
Improve daily report logic

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -303,7 +303,7 @@ async def zarobyty_cmd(message: types.Message) -> None:
 
     await message.answer("⏳ Формую звіт...")
 
-    report, _, updates = generate_zarobyty_report()
+    report, _, updates, gpt_text = generate_zarobyty_report()
     if not report:
         await message.answer(
             "⚠️ Звіт наразі недоступний. Спробуйте пізніше."
@@ -332,6 +332,9 @@ async def zarobyty_cmd(message: types.Message) -> None:
         )
 
     await message.answer(report, parse_mode="Markdown", reply_markup=keyboard)
+    MAX_LEN = 4000
+    for i in range(0, len(gpt_text), MAX_LEN):
+        await message.answer(gpt_text[i:i + MAX_LEN])
 
 
 def register_handlers(dp: Dispatcher) -> None:


### PR DESCRIPTION
## Summary
- loosen buy candidate filter
- split long GPT forecasts into multiple bot messages
- send forecast separately in Telegram bot

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68490be463b48329a891ae6fd5713046