### PR TITLE
Add ML training and prediction modules

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -1,6 +1,19 @@
-from binance_api import get_candlestick_klines
-from ml_model import train_and_save_model
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import classification_report
+import joblib
+from ml_model import generate_features, MODEL_PATH
 
-klines = get_candlestick_klines("BTC", interval="1d", limit=180)
-train_and_save_model(klines)
-print("✅ Модель навчена і збережена.")
+SYMBOL = "BTCUSDT"
+
+_, X_full, y_full = generate_features(SYMBOL)
+X_train, X_test, y_train, y_test = train_test_split(X_full, y_full, test_size=0.2, random_state=42)
+
+model = RandomForestClassifier(n_estimators=100, random_state=42)
+model.fit(X_train, y_train)
+
+y_pred = model.predict(X_test)
+print(classification_report(y_test, y_pred))
+
+joblib.dump(model, MODEL_PATH)
+print(f"✅ Model saved to {MODEL_PATH}")


### PR DESCRIPTION
## Summary
- implement new machine learning logic in `ml_model.py`
- add `train_model.py` for model training

## Testing
- `pip install scikit-learn pandas numpy joblib` *(passed)*
- `pip install python-binance` *(passed)*
- `python3 train_model.py` *(failed: Service unavailable from restricted location)*
- `python3 -c "from ml_model import predict_direction; print(predict_direction('BTCUSDT'))"` *(failed: Service unavailable from restricted location)*

------
https://chatgpt.com/codex/tasks/task_e_6849b9fa222883298172f07b83f827b2