### PR TITLE
Refactor feature generation in daily analysis

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -38,7 +38,7 @@ from utils import (
 from history import _load_history, get_failed_tokens_history
 from coingecko_api import get_sentiment
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
-from ml_model import load_model, predict_direction
+from ml_model import load_model, generate_features, predict_direction
 
 logger = logging.getLogger(__name__)
 
@@ -273,7 +273,7 @@ def generate_zarobyty_report() -> tuple[str, InlineKeyboardMarkup, list, str]:
         bb_ratio = (closes[-1] - (mid - 2 * stddev)) / (4 * stddev + 1e-8)
         volume_avg = statistics.fmean([float(k[5]) for k in klines[-5:]])
 
-        feature_vector = [momentum, rsi / 100, bb_ratio, volume_avg]
+        feature_vector, _, _ = generate_features(symbol)
         model = load_model()
         prob_up = predict_direction(model, feature_vector) if model else 0.5
 


### PR DESCRIPTION
## Summary
- import `generate_features` from `ml_model`
- use `generate_features` to build the feature vector before ML prediction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails to build aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_6849c98facf08329a43a4bf393799e1f