### PR TITLE
Add ML screener with symbol error handling

### DIFF
--- a/ml_model.py
+++ b/ml_model.py
@@ -78,6 +78,14 @@ def generate_features(symbol: str):
 
 def predict_direction(model, feature_vector):
     """Прогнозує напрямок руху (up/down) на основі переданої моделі та фічей."""
-    # ensure feature_vector has the correct shape for the model
     prediction = model.predict(np.asarray(feature_vector).reshape(1, -1))
     return "up" if prediction[0] == 1 else "down"
+
+
+def predict_prob_up(model, feature_vector) -> float:
+    """Return probability of price going up using ``model``."""
+    if hasattr(model, "predict_proba"):
+        probs = model.predict_proba(np.asarray(feature_vector).reshape(1, -1))
+        return float(probs[0][1])
+    direction = predict_direction(model, feature_vector)
+    return 1.0 if direction == "up" else 0.0

--- a/ml_screener.py
+++ b/ml_screener.py
@@ -1,0 +1,57 @@
+import os
+from typing import List, Dict
+from binance.client import Client
+
+from binance_api import get_symbol_price, get_candlestick_klines as get_klines
+from ml_model import load_model, generate_features, predict_prob_up
+from utils import dynamic_tp_sl, calculate_expected_profit
+
+client = Client(api_key=os.getenv("BINANCE_API_KEY"), api_secret=os.getenv("BINANCE_API_SECRET"))
+
+
+def get_valid_symbols() -> List[str]:
+    """Return all active USDT trading pairs from Binance."""
+    return [
+        s["symbol"].replace("USDT", "")
+        for s in client.get_exchange_info()["symbols"]
+        if s["quoteAsset"] == "USDT" and s["status"] == "TRADING" and s["isSpotTradingAllowed"]
+    ]
+
+
+def estimate_profit(symbol: str) -> float:
+    """Estimate expected profit for ``symbol`` using dynamic TP/SL."""
+    price = get_symbol_price(symbol)
+    klines = get_klines(symbol)
+    if not klines:
+        return 0.0
+    closes = [float(k[4]) for k in klines]
+    tp, sl = dynamic_tp_sl(closes, price)
+    return calculate_expected_profit(price, tp, amount=10, sl_price=sl)
+
+
+def get_candidates(symbols: List[str]) -> List[Dict[str, float]]:
+    """Return promising tokens ranked by ML probability."""
+    model = load_model()
+    candidates: List[Dict[str, float]] = []
+    for symbol in symbols:
+        try:
+            feature_vector, _, _ = generate_features(symbol)
+            prob_up = predict_prob_up(model, feature_vector) if model else 0.5
+            expected_profit = estimate_profit(symbol)
+            if prob_up > 0.5 and expected_profit > 0.005:
+                candidates.append({
+                    "symbol": symbol,
+                    "expected_profit": expected_profit,
+                    "prob_up": prob_up,
+                })
+        except Exception as e:  # noqa: BLE001
+            print(f"\u26A0\ufe0f \u041f\u0440\u043e\u043f\u0443\u0449\u0435\u043d\u043e {symbol}: {e}")
+            continue
+    return candidates
+
+
+if __name__ == "__main__":
+    symbols = get_valid_symbols()
+    tokens = get_candidates(symbols)
+    for t in tokens:
+        print(f"{t['symbol']}: prob_up={t['prob_up']:.2f}, expected={t['expected_profit']}")


### PR DESCRIPTION
## Summary
- add `predict_prob_up` helper to `ml_model`
- implement `ml_screener.py` to scan Binance symbols using the ML model

## Testing
- `python -m py_compile ml_screener.py ml_model.py`
- `pytest -q` *(fails: Binance API unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6849d0a83808832989f303522b150c88