### PR TITLE
Add autonomous trading loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from telegram_bot import (
     clear_bot_menu,
 )
 from binance_api import get_open_orders
+from daily_analysis import auto_trade_loop
 
 logging.basicConfig(level=logging.INFO)
 
@@ -45,4 +46,5 @@ if __name__ == "__main__":
     scheduler.add_job(check_tp_sl_market_change, "interval", hours=1)
     loop = asyncio.get_event_loop()
     loop.create_task(monitor_orders())
+    loop.create_task(auto_trade_loop())
     executor.start_polling(dp, on_startup=on_startup)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -304,7 +304,7 @@ async def zarobyty_cmd(message: types.Message) -> None:
 
     await message.answer("⏳ Формую звіт...")
 
-    report, _, updates, gpt_text = generate_zarobyty_report()
+    report, _, _, gpt_text = generate_zarobyty_report()
     if not report:
         await message.answer(
             "⚠️ Звіт наразі недоступний. Спробуйте пізніше."
@@ -327,10 +327,6 @@ async def zarobyty_cmd(message: types.Message) -> None:
         )
         keyboard.add(btn)
 
-    for sym, tp, sl in updates:
-        await message.answer(
-            f"\u267B\ufe0f Ордер оновлено: {sym} — новий TP: {tp}, SL: {sl}"
-        )
 
     await message.answer(report, parse_mode="Markdown", reply_markup=keyboard)
     MAX_LEN = 4000


### PR DESCRIPTION
## Summary
- implement automatic trading loop running every 10 minutes
- allow `place_market_order` to handle buy/sell market orders
- expose auto trade in main bot
- update daily report logic for fallback and new constant
- adjust telegram report handler

## Testing
- `python -m pip install -r requirements.txt` *(fails: building wheel for aiohttp)*
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_684a6f9655648329b6926e61e7175190