### PR TITLE
Fix aiohttp build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,16 @@
 ```bash
 git clone https://github.com/wooferOS/telegram-crypto-bot-github.git
 ```
+2. Встановіть пакети для компіляції C‑залежностей (наприклад `aiohttp`):
+```bash
+sudo apt update && sudo apt install -y build-essential python3-dev
+```
+3. Оновіть pip та перевстановіть `aiohttp` без кешу:
+```bash
+pip install --upgrade pip setuptools wheel
+pip install --no-cache-dir --force-reinstall aiohttp
+```
+4. Встановіть Python‑залежності:
+```bash
+pip install -r requirements.txt
+```

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,13 @@ exec > >(tee -a "$LOGFILE") 2>&1
 echo "$(date '+%F %T') 🔄 [DEPLOY] Оновлення Telegram GPT Bot..."
 cd ~/telegram-crypto-bot-github || exit 1
 
+echo "$(date '+%F %T') 📦 Встановлення системних залежностей..."
+sudo apt update && sudo apt install -y build-essential python3-dev
+
+echo "$(date '+%F %T') 📦 Оновлення pip та перевстановлення aiohttp..."
+pip install --upgrade pip setuptools wheel
+pip install --no-cache-dir --force-reinstall aiohttp
+
 echo "$(date '+%F %T') 📥 Підтягуємо останні зміни з GitHub..."
 git pull origin dev
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ cachetools>=5.3.2
 aiofiles>=23.2.1
 scikit-learn>=1.7.0
 joblib>=1.5.1
+aiohttp==3.9.3


### PR DESCRIPTION
## Summary
- document system packages for `aiohttp`
- reinstall `aiohttp` without cache in deployment script
- pin `aiohttp` version for easier installation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a75577038832999e44a164842824e