### PR TITLE
Fix USDT pair construction

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -359,7 +359,9 @@ def get_symbol_price(symbol: str) -> float:
     """Return current price of token to USDT."""
 
     try:
-        pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+        pair = symbol.upper()
+        if not pair.endswith("USDT"):
+            pair += "USDT"
         ticker = client.get_symbol_ticker(symbol=pair)
         return float(ticker.get("price", 0))
     except Exception as exc:
@@ -377,7 +379,9 @@ def get_token_price(symbol: str) -> dict:
     """Return token price with symbol."""
 
     try:
-        pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+        pair = symbol.upper()
+        if not pair.endswith("USDT"):
+            pair += "USDT"
         ticker = client.get_symbol_ticker(symbol=pair)
         return {"symbol": symbol.upper(), "price": ticker.get("price", "0")}
     except Exception as exc:  # pragma: no cover - network errors
@@ -388,7 +392,9 @@ def get_token_price(symbol: str) -> dict:
 def place_market_order(symbol: str, side: str, amount: float) -> Optional[Dict[str, object]]:
     """Place a market order for ``symbol`` on Binance."""
 
-    pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+    pair = symbol.upper()
+    if not pair.endswith("USDT"):
+        pair += "USDT"
     try:
         if side.upper() == "BUY":
             order = client.create_order(
@@ -420,7 +426,9 @@ def market_buy_symbol_by_amount(symbol: str, amount: float) -> Dict[str, object]
             raise Exception("Price unavailable")
 
         quantity = round(amount / price, 6)
-        pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+        pair = symbol.upper()
+        if not pair.endswith("USDT"):
+            pair += "USDT"
         return client.create_order(
             symbol=pair,
             side=SIDE_BUY,
@@ -487,7 +495,9 @@ def place_sell_order(symbol: str, quantity: float, price: float) -> bool:
     """Place a limit sell order on Binance."""
 
     try:
-        pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+        pair = symbol.upper()
+        if not pair.endswith("USDT"):
+            pair += "USDT"
         order = client.create_order(
             symbol=pair,
             side="SELL",
@@ -506,7 +516,9 @@ def place_limit_sell(symbol: str, quantity: float) -> dict:
     """Place a LIMIT sell order at current market price."""
     price = get_symbol_price(symbol)
     try:
-        pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+        pair = symbol.upper()
+        if not pair.endswith("USDT"):
+            pair += "USDT"
         order = client.create_order(
             symbol=pair,
             side="SELL",
@@ -592,7 +604,9 @@ def place_stop_limit_buy_order(
     """Create STOP_LIMIT BUY order on Binance."""
 
     try:
-        pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+        pair = symbol.upper()
+        if not pair.endswith("USDT"):
+            pair += "USDT"
         order = client.create_order(
             symbol=pair,
             side="BUY",
@@ -619,7 +633,9 @@ def place_stop_limit_sell_order(
     """Create STOP_LIMIT SELL order on Binance."""
 
     try:
-        pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+        pair = symbol.upper()
+        if not pair.endswith("USDT"):
+            pair += "USDT"
         order = client.create_order(
             symbol=pair,
             side="SELL",
@@ -701,7 +717,9 @@ def cancel_order(order_id: int, symbol: str = "USDTBTC") -> bool:
 def update_tp_sl_order(symbol: str, new_tp_price: float, new_sl_price: float) -> Dict[str, int] | None:
     """Refresh TP/SL orders for ``symbol`` with new prices."""
 
-    pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+    pair = symbol.upper()
+    if not pair.endswith("USDT"):
+        pair += "USDT"
 
     cancel_all_orders(pair)
 
@@ -729,7 +747,9 @@ def modify_order(symbol: str, new_tp: float, new_sl: float) -> bool:
 def cancel_tp_sl_if_market_changed(symbol: str) -> None:
     """Cancel TP/SL orders if market price moved more than 5%."""
 
-    pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+    pair = symbol.upper()
+    if not pair.endswith("USDT"):
+        pair += "USDT"
     orders = get_open_orders(pair)
     if not orders:
         return
@@ -805,7 +825,9 @@ def get_coin_price(symbol: str) -> Optional[float]:
     """Return last known coin price using direct HTTP call."""
 
     url = f"{BINANCE_BASE_URL}/api/v3/ticker/price"
-    pair = symbol.upper() if str(symbol).upper().endswith("USDT") else f"{symbol.upper()}USDT"
+    pair = symbol.upper()
+    if not pair.endswith("USDT"):
+        pair += "USDT"
     try:
         resp = requests.get(url, params={"symbol": pair}, timeout=5)
         resp.raise_for_status()
@@ -885,7 +907,9 @@ def get_price_history_24h(symbol: str) -> Optional[List[float]]:
     """Return list of hourly close prices for the last 24 hours."""
 
     url = f"{BINANCE_BASE_URL}/api/v3/klines"
-    pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+    pair = symbol.upper()
+    if not pair.endswith("USDT"):
+        pair += "USDT"
     params = {"symbol": pair, "interval": "1h", "limit": 24}
     try:
         resp = requests.get(url, params=params, timeout=5)
@@ -904,7 +928,9 @@ def get_price_history_24h(symbol: str) -> Optional[List[float]]:
 def get_candlestick_klines(symbol: str, interval: str = "1h", limit: int = 100) -> List[List[float]]:
     """Return raw candlestick klines for a symbol."""
     url = f"{BINANCE_BASE_URL}/api/v3/klines"
-    pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+    pair = symbol.upper()
+    if not pair.endswith("USDT"):
+        pair += "USDT"
     params = {"symbol": pair, "interval": interval, "limit": limit}
     try:
         response = requests.get(url, params=params, timeout=10)
@@ -941,7 +967,10 @@ def get_real_pnl_data() -> Dict[str, Dict[str, float]]:
             continue
 
         try:
-            trades = client.get_my_trades(symbol=f"{asset}USDT", limit=5)
+            pair = asset.upper()
+            if not pair.endswith("USDT"):
+                pair += "USDT"
+            trades = client.get_my_trades(symbol=pair, limit=5)
             if not trades:
                 continue
 
@@ -1150,8 +1179,11 @@ def place_take_profit_order_auto(symbol: str, quantity: float | None = None, tar
             balance = get_token_balance(symbol.replace("USDT", ""))
             quantity = round(balance * 0.99, 5)
 
+        pair = symbol.upper()
+        if not pair.endswith("USDT"):
+            pair += "USDT"
         params = {
-            "symbol": symbol.upper() if symbol.upper().endswith("USDT") else symbol.upper() + "USDT",
+            "symbol": pair,
             "side": "SELL",
             "type": "LIMIT",
             "quantity": quantity,
@@ -1175,8 +1207,11 @@ def place_stop_loss_order_auto(symbol: str, quantity: float | None = None, stop_
             balance = get_token_balance(symbol.replace("USDT", ""))
             quantity = round(balance * 0.99, 5)
 
+        pair = symbol.upper()
+        if not pair.endswith("USDT"):
+            pair += "USDT"
         params = {
-            "symbol": symbol.upper() if symbol.upper().endswith("USDT") else symbol.upper() + "USDT",
+            "symbol": pair,
             "side": "SELL",
             "type": "STOP_LOSS_LIMIT",
             "quantity": quantity,
@@ -1204,7 +1239,9 @@ def get_candlestick_klines(symbol: str, interval: str = "1d", limit: int = 7):
 
     if symbol not in load_tradable_usdt_symbols():
         raise ValueError(f"Token {symbol} не торгується на Binance")
-    pair = symbol.upper() if symbol.upper().endswith("USDT") else f"{symbol.upper()}USDT"
+    pair = symbol.upper()
+    if not pair.endswith("USDT"):
+        pair += "USDT"
     return client.get_klines(
         symbol=pair,
         interval=interval,


### PR DESCRIPTION
## Summary
- prevent duplicate `USDT` suffixes when building trading pairs
- update all Binance API helpers to use safe pair construction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError / Binance API unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684a7dcdd784832996fdaebd576b94db