### PR TITLE
Fix VALID_PAIRS handling

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -39,6 +39,8 @@ from binance_api import (
     log_tp_sl_change,
     get_usdt_balance,
     get_token_balance,
+    VALID_PAIRS,
+    refresh_valid_pairs,
 )
 from binance_api import get_candlestick_klines
 from config import MIN_PROB_UP, MIN_EXPECTED_PROFIT, MIN_TRADE_AMOUNT, TRADE_LOOP_INTERVAL
@@ -246,6 +248,12 @@ def generate_zarobyty_report() -> tuple[str, list, list, str]:
     now = datetime.datetime.now(pytz.timezone("Europe/Kyiv"))
     token_data = []
 
+    if len(VALID_PAIRS) < 50:
+        logger.warning(
+            "⚠️ VALID_PAIRS містить лише %d символів — можливі помилки",
+            len(VALID_PAIRS),
+        )
+
     for symbol, amount in balances.items():
         if symbol == "USDT" or amount == 0:
             continue
@@ -322,7 +330,7 @@ def generate_zarobyty_report() -> tuple[str, list, list, str]:
                     }
                 )
         except Exception as e:
-            print(f"⚠️ Пропущено {symbol}: {e}")
+            logger.warning(f"⚠️ Пропущено {symbol}: {str(e)}")
             continue
 
     buy_candidates.sort(key=lambda x: x["score"], reverse=True)


### PR DESCRIPTION
## Summary
- refresh VALID_PAIRS from Binance at startup
- retry pair lookup when price/order functions can't find a symbol
- log skipped symbols with error details in daily report
- warn when too few trading pairs are loaded
- expose a helper to quickly test a few common pairs

## Testing
- `python -m py_compile binance_api.py daily_analysis.py`
- `pytest -q` *(fails: Binance API not reachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_684a8427fc608329a08d9312a530d9b8