### PR TITLE
Fix initialization of Binance VALID_PAIRS

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -127,8 +127,6 @@ def is_symbol_valid(symbol: str) -> bool:
         refresh_valid_pairs()
     return pair in VALID_PAIRS
 
-# Load available USDT trading pairs once on startup
-refresh_valid_pairs()
 
 
 # ---------------------------------------------------------------------------
@@ -222,6 +220,9 @@ def get_valid_usdt_symbols() -> list[str]:
     """Return list of tradable USDT pairs from Binance."""
 
     return get_valid_symbols("USDT")
+
+# Load available USDT trading pairs once on startup
+refresh_valid_pairs()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- avoid NameError by calling `refresh_valid_pairs()` only after `get_exchange_info_cached` is defined

## Testing
- `python -m py_compile binance_api.py`
- `pip install -q -r requirements.txt` *(fails: Failed building wheel for aiohttp)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684aa2da92f08329a106e7141a321b89