### PR TITLE
Fix symbol validation and logging

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -125,7 +125,9 @@ def is_symbol_valid(symbol: str) -> bool:
     pair = _to_usdt_pair(symbol)
     if not VALID_PAIRS:
         refresh_valid_pairs()
-    return pair in VALID_PAIRS
+    is_valid = pair in VALID_PAIRS
+    logger.info("is_symbol_valid(%s) -> %s (pair=%s)", symbol, is_valid, pair)
+    return is_valid
 
 
 

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -310,13 +310,14 @@ def generate_zarobyty_report() -> tuple[str, list, list, str]:
     success = 0
     fail = 0
     for sym in symbols:
-        if is_symbol_valid(sym):
-            symbols_to_analyze.append(sym)
+        pair = sym if sym.endswith("USDT") else f"{sym}USDT"
+        if is_symbol_valid(pair):
+            symbols_to_analyze.append(pair)
             success += 1
         else:
             logger.info(
                 "⏭️ Пропущено %s: не торгується. valid_symbols=%s",
-                sym,
+                pair,
                 valid_symbols,
             )
             fail += 1


### PR DESCRIPTION
## Summary
- fix `is_symbol_valid` logging and return value
- use explicit USDT pair when validating symbols

## Testing
- `pytest -q` *(fails: Binance API unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684aac947edc8329afe22275ea278d84