### PR TITLE
Add debug output in generate report

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -341,6 +341,7 @@ def generate_zarobyty_report() -> tuple[str, list, list, str]:
             fv = np.asarray(feature_vector).reshape(1, -1)
             prob_up = predict_prob_up(model, fv) if model else 0.5
             expected_profit = estimate_profit(symbol)
+            print(f"\U0001F4CA {symbol}: prob_up={prob_up:.2f}, expected_profit={expected_profit}")
 
             enriched_tokens.append(
                 {


### PR DESCRIPTION
## Summary
- add a print statement in `generate_zarobyty_report`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684ae5780e008329ac74b316f09681e2