### PR TITLE
Implement hourly auto trading

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,4 +7,4 @@ MIN_EXPECTED_PROFIT = 0.3
 MIN_TRADE_AMOUNT = float(os.getenv("MIN_TRADE_AMOUNT", 10))  # USDT
 
 # Auto trading loop interval in seconds
-TRADE_LOOP_INTERVAL = int(os.getenv("TRADE_LOOP_INTERVAL", 600))
+TRADE_LOOP_INTERVAL = int(os.getenv("TRADE_LOOP_INTERVAL", 3600))

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -690,7 +690,6 @@ if __name__ == "__main__":
 
     if TELEGRAM_TOKEN and CHAT_ID:
         bot = Bot(token=TELEGRAM_TOKEN)
-        # asyncio.run(daily_analysis_task(bot, int(CHAT_ID)))
-        asyncio.run(auto_trade_loop())  # ← Увімкни цей рядок
+        asyncio.run(auto_trade_loop())
     else:
         print("❌ TELEGRAM_TOKEN або CHAT_ID не встановлено")


### PR DESCRIPTION
## Summary
- set trade thresholds and interval in config
- always choose fallback buy candidate
- run auto trade loop when starting analysis

## Testing
- `pytest -q` *(fails: Binance API restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684afb544a908329ae85f9f6cf24e0ee