### PR TITLE
Fix CHAT_ID import for daily analysis

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,3 +8,6 @@ MIN_TRADE_AMOUNT = float(os.getenv("MIN_TRADE_AMOUNT", 10))  # USDT
 
 # Auto trading loop interval in seconds
 TRADE_LOOP_INTERVAL = int(os.getenv("TRADE_LOOP_INTERVAL", 3600))
+
+
+CHAT_ID = os.getenv("CHAT_ID")


### PR DESCRIPTION
## Summary
- load `CHAT_ID` from environment in `config.py`
- keep `run_daily_analysis.py` simple

## Testing
- `python3 run_daily_analysis.py` *(fails: ModuleNotFoundError: No module named 'aiogram')*
- `python3 -m pip install -r requirements.txt` *(fails: Failed to build aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_684be722ebf08329a1f8b3678680b1cd