### PR TITLE
Enable console logging

### DIFF
--- a/run_auto_trade_cycle.py
+++ b/run_auto_trade_cycle.py
@@ -1,12 +1,19 @@
 import asyncio
 import logging
+import sys
 
 from telegram_bot import bot
 from config import CHAT_ID
 from auto_trade_cycle import auto_trade_cycle
 
 LOG_PATH = "/root/trade.log"
-logging.basicConfig(filename=LOG_PATH, level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    handlers=[
+        logging.FileHandler(LOG_PATH),
+        logging.StreamHandler(sys.stdout),
+    ],
+)
 
 if __name__ == "__main__":
     chat_id = int(CHAT_ID) if CHAT_ID else 0


### PR DESCRIPTION
## Summary
- log trade cycle activity to `/root/trade.log`
- stream logs to stdout so they are visible with `tee`

## Testing
- `python -m py_compile run_auto_trade_cycle.py`

------
https://chatgpt.com/codex/tasks/task_e_684bfd3f3be88329b570ecb319a24e16