### PR TITLE
Improve convert-to-USDT warnings

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -74,7 +74,7 @@ async def auto_trade_cycle(bot, chat_id: int) -> None:
             if result.get("status") != "error":
                 actions_made = True
             else:
-                conv = convert_to_usdt(asset, amount)
+                conv = convert_to_usdt(asset, amount, forecast)
                 if conv is not None:
                     actions_made = True
                 else:


### PR DESCRIPTION
## Summary
- enhance `try_convert` warnings with forecast info
- allow `convert_to_usdt`/`try_convert` to accept forecast data
- pass forecast in auto trade cycle when manual conversion is required

## Testing
- `python3 -m pip install -r requirements.txt` *(fails: build error for aiohttp)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0b13072c8329b6c46e8258e7627b