### PR TITLE
Refactor configuration access

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -1,13 +1,12 @@
 """Utilities for storing and checking pending trading alerts."""
 
 import json
-import os
 import logging
 from datetime import datetime, timedelta
 from typing import List, Dict
 
 logger = logging.getLogger(__name__)
-ALERTS_FILE = os.getenv("ALERTS_FILE", "pending_alerts.json")
+from config import ALERTS_FILE
 
 
 def _load_alerts() -> List[Dict]:

--- a/binance_api.py
+++ b/binance_api.py
@@ -33,8 +33,13 @@ from binance.exceptions import BinanceAPIException
 logger = logging.getLogger(__name__)
 TELEGRAM_LOG_PREFIX = "\ud83d\udce1 [BINANCE]"
 
-BINANCE_API_KEY = os.getenv("BINANCE_API_KEY")
-BINANCE_SECRET_KEY = os.getenv("BINANCE_SECRET_KEY")
+from config import (
+    BINANCE_API_KEY,
+    BINANCE_SECRET_KEY,
+    TELEGRAM_TOKEN,
+    ADMIN_CHAT_ID,
+    CHAT_ID,
+)
 
 if not BINANCE_API_KEY or not BINANCE_SECRET_KEY:
     raise ValueError(
@@ -362,12 +367,8 @@ def get_binance_balances() -> Dict[str, float]:
     """Return available balances with automatic API diagnostics."""
 
     try:
-        api_key = os.getenv("BINANCE_API_KEY")
-        secret_key = os.getenv("BINANCE_SECRET_KEY")
-        if not api_key or not secret_key:
-            raise ValueError(
-                "BINANCE_API_KEY and BINANCE_SECRET_KEY must be provided in the environment"
-            )
+        api_key = BINANCE_API_KEY
+        secret_key = BINANCE_SECRET_KEY
 
         temp_client = Client(api_key, secret_key)
 
@@ -1173,8 +1174,8 @@ def get_token_value_in_uah(symbol: str) -> float:
 def notify_telegram(message: str) -> None:
     """Send a notification to Telegram if credentials are configured."""
 
-    token = os.getenv("TELEGRAM_TOKEN")
-    chat_id = os.getenv("ADMIN_CHAT_ID", os.getenv("CHAT_ID", ""))
+    token = TELEGRAM_TOKEN
+    chat_id = ADMIN_CHAT_ID or CHAT_ID
     if not token or not chat_id:
         logger.debug("%s Telegram credentials not set", TELEGRAM_LOG_PREFIX)
         return

--- a/coingecko_api.py
+++ b/coingecko_api.py
@@ -4,6 +4,8 @@ import logging
 import requests
 from typing import Optional, Dict
 
+from config import COINGECKO_API_KEY
+
 BASE_URL = "https://api.coingecko.com/api/v3"
 logger = logging.getLogger(__name__)
 
@@ -18,8 +20,9 @@ def get_coin_market_data(coin_id: str) -> Optional[Dict]:
         "developer_data": "false",
         "sparkline": "false",
     }
+    headers = {"x-cg-pro-api-key": COINGECKO_API_KEY} if COINGECKO_API_KEY else None
     try:
-        resp = requests.get(url, params=params, timeout=10)
+        resp = requests.get(url, params=params, headers=headers, timeout=10)
         resp.raise_for_status()
         data = resp.json().get("market_data", {})
         return {
@@ -45,8 +48,9 @@ def get_market_data(token: str) -> Optional[Dict]:
 def get_sentiment() -> str:
     """Return 'Bullish', 'Neutral' or 'Bearish' based on market cap change."""
     url = f"{BASE_URL}/global"
+    headers = {"x-cg-pro-api-key": COINGECKO_API_KEY} if COINGECKO_API_KEY else None
     try:
-        resp = requests.get(url, timeout=10)
+        resp = requests.get(url, headers=headers, timeout=10)
         resp.raise_for_status()
         change = resp.json().get("data", {}).get(
             "market_cap_change_percentage_24h_usd", 0

--- a/config.py
+++ b/config.py
@@ -1,13 +1,23 @@
 import os
 
+# Required credentials
+TELEGRAM_TOKEN = os.environ["TELEGRAM_TOKEN"]
+CHAT_ID = os.environ["CHAT_ID"]
+ADMIN_CHAT_ID = int(os.environ.get("ADMIN_CHAT_ID", CHAT_ID))
+OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+COINGECKO_API_KEY = os.environ.get("COINGECKO_API_KEY", "")
+BINANCE_API_KEY = os.environ["BINANCE_API_KEY"]
+BINANCE_SECRET_KEY = os.environ.get("BINANCE_SECRET_KEY") or os.environ["BINANCE_API_SECRET"]
+BINANCE_API_SECRET = BINANCE_SECRET_KEY  # alias for compatibility
+
 # Thresholds for trading decisions
-# Updated trading thresholds
 MIN_PROB_UP = 0.45
 MIN_EXPECTED_PROFIT = 0.3
-MIN_TRADE_AMOUNT = float(os.getenv("MIN_TRADE_AMOUNT", 10))  # USDT
+MIN_TRADE_AMOUNT = float(os.environ.get("MIN_TRADE_AMOUNT", 10))  # USDT
 
 # Auto trading loop interval in seconds
-TRADE_LOOP_INTERVAL = int(os.getenv("TRADE_LOOP_INTERVAL", 3600))
+TRADE_LOOP_INTERVAL = int(os.environ.get("TRADE_LOOP_INTERVAL", 3600))
 
-
-CHAT_ID = os.getenv("CHAT_ID")
+# Storage files
+HISTORY_FILE = os.environ.get("HISTORY_FILE", "trade_history.json")
+ALERTS_FILE = os.environ.get("ALERTS_FILE", "pending_alerts.json")

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -6,7 +6,6 @@ import asyncio
 import pytz
 import statistics
 import logging
-import os
 import numpy as np
 
 from binance_api import (
@@ -702,12 +701,9 @@ def demo_candidates_loop(symbols: list[str]) -> list[dict]:
 
 if __name__ == "__main__":
     import asyncio
-    import os
     import sys
     from telegram import Bot
-
-    TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
-    CHAT_ID = os.getenv("CHAT_ID")
+    from config import TELEGRAM_TOKEN, CHAT_ID
 
     if len(sys.argv) > 1 and sys.argv[1] == "demo":
         candidates = demo_candidates_loop(symbols)

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -1,9 +1,8 @@
 from typing import Dict, Any
 
 from openai import OpenAI
-import os
+from config import OPENAI_API_KEY
 
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 client = OpenAI(api_key=OPENAI_API_KEY)
 
 

--- a/history.py
+++ b/history.py
@@ -1,13 +1,12 @@
 """Simple storage helpers for keeping trade history."""
 
 import json
-import os
 import logging
 from datetime import datetime
 from typing import List, Dict
 
 logger = logging.getLogger(__name__)
-HISTORY_FILE = os.getenv("HISTORY_FILE", "trade_history.json")
+from config import HISTORY_FILE
 
 
 def _load_history() -> List[Dict]:

--- a/ml_model.py
+++ b/ml_model.py
@@ -9,10 +9,11 @@ from binance.client import Client
 from sklearn.ensemble import RandomForestClassifier
 
 from binance_api import _to_usdt_pair, is_symbol_valid
+from config import BINANCE_API_KEY, BINANCE_API_SECRET
 
 MODEL_PATH = "model.joblib"
 
-client = Client(api_key=os.getenv("BINANCE_API_KEY"), api_secret=os.getenv("BINANCE_API_SECRET"))
+client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_API_SECRET)
 
 def load_model():
     if os.path.exists(MODEL_PATH):

--- a/ml_screener.py
+++ b/ml_screener.py
@@ -1,4 +1,3 @@
-import os
 from typing import List, Dict
 from binance.client import Client
 
@@ -6,8 +5,9 @@ from binance_api import get_symbol_price, get_candlestick_klines as get_klines
 import numpy as np
 from ml_model import load_model, generate_features, predict_prob_up
 from utils import dynamic_tp_sl, calculate_expected_profit
+from config import BINANCE_API_KEY, BINANCE_API_SECRET
 
-client = Client(api_key=os.getenv("BINANCE_API_KEY"), api_secret=os.getenv("BINANCE_API_SECRET"))
+client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_API_SECRET)
 
 
 def get_valid_symbols() -> List[str]:

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,6 +1,5 @@
 """Telegram bot configuration and handlers."""
 
-import os
 import logging
 import datetime
 from aiogram import Bot, Dispatcher, types
@@ -55,11 +54,9 @@ from binance_api import (
     cancel_tp_sl_if_market_changed,
 )
 from alerts import check_daily_alerts
+from config import TELEGRAM_TOKEN, CHAT_ID, ADMIN_CHAT_ID
 
 take_profit_cb = CallbackData("tp", "symbol", "amount")
-
-TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
-ADMIN_CHAT_ID = int(os.getenv("ADMIN_CHAT_ID", os.getenv("CHAT_ID", "0")))
 
 bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher(bot)

--- a/train_model.py
+++ b/train_model.py
@@ -5,13 +5,11 @@ from binance.client import Client
 from ml_model import generate_features, MODEL_PATH
 import joblib
 import numpy as np
-import os
+from config import BINANCE_API_KEY, BINANCE_API_SECRET
 import time
 import subprocess
 
-api_key = os.getenv("BINANCE_API_KEY")
-api_secret = os.getenv("BINANCE_API_SECRET")
-client = Client(api_key=api_key, api_secret=api_secret)
+client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_API_SECRET)
 
 
 def get_all_usdt_symbols(min_volume=500000):


### PR DESCRIPTION
## Summary
- centralize all API keys and paths in `config.py`
- refactor Telegram bot and utilities to import constants from config
- pass CoinGecko API key via request headers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt` *(fails: building wheel for `aiohttp`)*

------
https://chatgpt.com/codex/tasks/task_e_684d04ca68c8832984782cc9b10f6372