### PR TITLE
Remove os.environ usage from config

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,23 +1,21 @@
-import os
-
 # Required credentials
-TELEGRAM_TOKEN = os.environ["TELEGRAM_TOKEN"]
-CHAT_ID = os.environ["CHAT_ID"]
-ADMIN_CHAT_ID = int(os.environ.get("ADMIN_CHAT_ID", CHAT_ID))
-OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
-COINGECKO_API_KEY = os.environ.get("COINGECKO_API_KEY", "")
-BINANCE_API_KEY = os.environ["BINANCE_API_KEY"]
-BINANCE_SECRET_KEY = os.environ.get("BINANCE_SECRET_KEY") or os.environ["BINANCE_API_SECRET"]
+TELEGRAM_TOKEN = "123456:ABC..."
+CHAT_ID = "123456789"
+ADMIN_CHAT_ID = int(CHAT_ID)
+OPENAI_API_KEY = "sk-..."
+COINGECKO_API_KEY = "..."
+BINANCE_API_KEY = "abc..."
+BINANCE_SECRET_KEY = "def..."
 BINANCE_API_SECRET = BINANCE_SECRET_KEY  # alias for compatibility
 
 # Thresholds for trading decisions
 MIN_PROB_UP = 0.45
 MIN_EXPECTED_PROFIT = 0.3
-MIN_TRADE_AMOUNT = float(os.environ.get("MIN_TRADE_AMOUNT", 10))  # USDT
+MIN_TRADE_AMOUNT = 10  # USDT
 
 # Auto trading loop interval in seconds
-TRADE_LOOP_INTERVAL = int(os.environ.get("TRADE_LOOP_INTERVAL", 3600))
+TRADE_LOOP_INTERVAL = 3600
 
 # Storage files
-HISTORY_FILE = os.environ.get("HISTORY_FILE", "trade_history.json")
-ALERTS_FILE = os.environ.get("ALERTS_FILE", "pending_alerts.json")
+HISTORY_FILE = "trade_history.json"
+ALERTS_FILE = "pending_alerts.json"


### PR DESCRIPTION
## Summary
- set static tokens in `config.py`

## Testing
- `python -m py_compile config.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: building wheel for aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_684d07cb63408329bab7be9097f9bab9