### PR TITLE
Fix lazy init for Binance and Telegram clients

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -58,7 +58,16 @@ from config import TELEGRAM_TOKEN, CHAT_ID, ADMIN_CHAT_ID
 
 take_profit_cb = CallbackData("tp", "symbol", "amount")
 
-bot = Bot(token=TELEGRAM_TOKEN)
+
+def get_bot() -> Bot:
+    """Return a Telegram ``Bot`` initialised with the loaded token."""
+
+    from config import TELEGRAM_TOKEN as TOKEN
+
+    return Bot(token=TOKEN)
+
+
+bot = get_bot()
 dp = Dispatcher(bot)
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- lazily create Binance client via `get_binance_client`
- ensure Telegram bot is created via helper after config loads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684d0f70727c8329af3a1c230944fd0d