### PR TITLE
Ensure Binance client loads after env

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -333,8 +333,7 @@ def get_valid_usdt_symbols() -> list[str]:
 
     return get_valid_symbols("USDT")
 
-# Load available USDT trading pairs once on startup
-refresh_valid_pairs()
+# Load available USDT trading pairs lazily on first use
 
 
 # ---------------------------------------------------------------------------

--- a/main.py
+++ b/main.py
@@ -2,6 +2,11 @@ import logging
 import asyncio
 from aiogram import Dispatcher
 from aiogram.utils import executor
+
+from secure_env_loader import load_env_file
+
+load_env_file("/root/.env")
+
 from telegram_bot import (
     dp,
     bot,

--- a/ml_model.py
+++ b/ml_model.py
@@ -11,7 +11,6 @@ from binance_api import _to_usdt_pair, is_symbol_valid, get_binance_client
 
 MODEL_PATH = "model.joblib"
 
-client = get_binance_client()
 
 def load_model():
     if os.path.exists(MODEL_PATH):
@@ -24,6 +23,7 @@ def get_klines(symbol: str, interval: str = "1h", limit: int = 500) -> pd.DataFr
     if not is_symbol_valid(symbol):
         logging.warning("%s not valid for klines", pair)
         return pd.DataFrame()
+    client = get_binance_client()
     try:
         data = client.get_klines(symbol=pair, interval=interval, limit=limit)
     except Exception as e:  # noqa: BLE001

--- a/ml_screener.py
+++ b/ml_screener.py
@@ -9,11 +9,11 @@ import numpy as np
 from ml_model import load_model, generate_features, predict_prob_up
 from utils import dynamic_tp_sl, calculate_expected_profit
 
-client = get_binance_client()
 
 
 def get_valid_symbols() -> List[str]:
     """Return all active USDT trading pairs from Binance."""
+    client = get_binance_client()
     return [
         s["symbol"]
         for s in client.get_exchange_info()["symbols"]

--- a/run_auto_trade_cycle.py
+++ b/run_auto_trade_cycle.py
@@ -2,6 +2,10 @@ import asyncio
 import logging
 import sys
 
+from secure_env_loader import load_env_file
+
+load_env_file("/root/.env")
+
 from telegram_bot import bot
 from config import CHAT_ID
 from auto_trade_cycle import auto_trade_cycle

--- a/run_daily_analysis.py
+++ b/run_daily_analysis.py
@@ -1,4 +1,9 @@
 import asyncio
+
+from secure_env_loader import load_env_file
+
+load_env_file("/root/.env")
+
 from telegram_bot import bot
 from config import CHAT_ID
 from daily_analysis import daily_analysis_task

--- a/train_model.py
+++ b/train_model.py
@@ -8,10 +8,10 @@ from binance_api import get_binance_client
 import time
 import subprocess
 
-client = get_binance_client()
 
 
 def get_all_usdt_symbols(min_volume=500000):
+    client = get_binance_client()
     tickers = client.get_ticker()
     result = []
     for t in tickers:


### PR DESCRIPTION
## Summary
- initialize environment before using Telegram or Binance APIs
- use fresh Binance client inside ML modules
- load tradable pair list lazily

## Testing
- `python -m py_compile binance_api.py daily_analysis.py main.py auto_trade_cycle.py telegram_bot.py ml_model.py ml_screener.py train_model.py run_auto_trade_cycle.py run_daily_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_684d1fb07e3c83298a0c33666f08352a