### PR TITLE
Implement periodic USDT balance warning

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -58,6 +58,9 @@ from ml_model import (
 )
 from telegram import Bot
 
+import time
+last_no_usdt_warning = 0
+
 symbols = get_valid_usdt_symbols()
 
 logger = logging.getLogger(__name__)
@@ -479,8 +482,12 @@ async def auto_trade_loop():
             if buy_candidates:
                 if not balance:
                     logger.warning("USDT balance unavailable for buying")
-                    from telegram_bot import bot, ADMIN_CHAT_ID
-                    await bot.send_message(ADMIN_CHAT_ID, "\u26A0\ufe0f Немає USDT для покупки")
+                    now = time.time()
+                    global last_no_usdt_warning
+                    if now - last_no_usdt_warning > 4500:
+                        last_no_usdt_warning = now
+                        from telegram_bot import bot, ADMIN_CHAT_ID
+                        await bot.send_message(ADMIN_CHAT_ID, "\u26A0\ufe0f Немає USDT для покупки")
                     await asyncio.sleep(TRADE_LOOP_INTERVAL)
                     continue
                 for candidate in buy_candidates:


### PR DESCRIPTION
## Summary
- send the "no USDT" warning at most every 4500 seconds
- import `time` and track `last_no_usdt_warning`

## Testing
- `python -m py_compile daily_analysis.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'binance')*

------
https://chatgpt.com/codex/tasks/task_e_684fa31360548329bb7db1ffe572038e