### PR TITLE
Fix TELEGRAM_TOKEN reference in auto_trade_cycle

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
+import os
 from typing import Dict, List, Optional
 
-from telegram import Bot
+from aiogram import Bot
 
 from binance_api import (
     get_binance_balances,
@@ -14,7 +15,6 @@ from ml_model import load_model, generate_features, predict_prob_up
 from utils import dynamic_tp_sl, calculate_expected_profit
 from daily_analysis import split_telegram_message
 from config import (
-    TELEGRAM_TOKEN,
     CHAT_ID,
     MIN_EXPECTED_PROFIT,
     MIN_PROB_UP,
@@ -129,7 +129,7 @@ async def send_conversion_signals(signals: List[Dict[str, float]]) -> None:
         logger.info("No conversion signals generated")
         return
 
-    bot = Bot(token=TELEGRAM_TOKEN)
+    bot = Bot(token=os.getenv("TELEGRAM_TOKEN"))
     lines = []
     for s in signals:
         lines.append(


### PR DESCRIPTION
## Summary
- switch to aiogram Bot and pull TELEGRAM_TOKEN from env

## Testing
- `python -m py_compile auto_trade_cycle.py`

------
https://chatgpt.com/codex/tasks/task_e_68510a55f59083299925c93fb3e51b59