### PR TITLE
Load Telegram settings from env

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -14,11 +14,10 @@ from binance_api import (
 from ml_model import load_model, generate_features, predict_prob_up
 from utils import dynamic_tp_sl, calculate_expected_profit
 from daily_analysis import split_telegram_message
-from config import (
-    CHAT_ID,
-    MIN_EXPECTED_PROFIT,
-    MIN_PROB_UP,
-)
+from config import MIN_EXPECTED_PROFIT, MIN_PROB_UP
+
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+CHAT_ID = os.getenv("CHAT_ID")
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- import constants from env in auto_trade_cycle

## Testing
- `pytest -q` *(fails: Binance API error due to service unavailable from restricted location)*

------
https://chatgpt.com/codex/tasks/task_e_68510bd28dac83298c1ed5318555ee50