### PR TITLE
Fix aiogram session closing

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -149,7 +149,8 @@ async def send_conversion_signals(signals: List[Dict[str, float]]) -> None:
         for part in split_telegram_message(text, 4000):
             await bot.send_message(CHAT_ID, part)
     finally:
-        await bot.session.close()
+        session = await bot.get_session()
+        await session.close()
 
 
 async def main() -> None:


### PR DESCRIPTION
## Summary
- prevent `DeprecationWarning` when closing Bot session

## Testing
- `pytest -q` *(fails: ModuleNotFoundError/connection issues)*

------
https://chatgpt.com/codex/tasks/task_e_6851280ad2e88329a06ba045c1dc2f36