### PR TITLE
Fix conversion signal flow and remove .env loading

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -80,7 +80,7 @@ def generate_conversion_signals() -> tuple[List[Dict[str, float]], bool]:
             predictions[pair] = data
 
     if not predictions:
-        return []
+        return [], False
 
     best_pair, best_data = max(
         (
@@ -185,7 +185,7 @@ async def send_conversion_signals(
             logger.info("No conversion signals generated")
             await bot.send_message(
                 CHAT_ID,
-                "\u26A0\ufe0f \u041d\u0435 \u0437\u043d\u0430\u0439\u0434\u0435\u043d\u043e \u0432\u0438\u0433\u0456\u0434\u043d\u0438\u0445 \u0441\u0438\u0433\u043d\u0430\u043b\u0456\u0432, \u0430\u043b\u0435 \u043e\u0447\u0456\u043a\u0443\u0432\u0430\u043d\u0438\u0439 \u043f\u0440\u0438\u0431\u0443\u0442\u043e\u043a \u0431\u0443\u0432 \u043d\u0438\u0437\u044c\u043a\u0438\u0439. \u041f\u0435\u0440\u0435\u0432\u0456\u0440 \u0432\u0440\u0443\u0447\u043d\u0443.",
+                "\u26A0\ufe0f \u041d\u0435\u043c\u0430\u0454 \u0430\u043a\u0442\u0438\u0432\u0456\u0432 \u0434\u043b\u044f \u043f\u0440\u043e\u0434\u0430\u0436\u0443 / \u043a\u0443\u043f\u0456\u0432\u043b\u0456",
             )
             return
 

--- a/binance_api.py
+++ b/binance_api.py
@@ -7,9 +7,6 @@ API and is designed for use in a Telegram bot.
 
 from __future__ import annotations
 
-from dotenv import load_dotenv
-load_dotenv(dotenv_path="/root/.env")  # Завантаження реального .env із сервера
-
 import os
 import time
 import hmac

--- a/telegram_sender.py
+++ b/telegram_sender.py
@@ -1,9 +1,7 @@
-from dotenv import load_dotenv
 import os
-load_dotenv("/root/.env")
+
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 CHAT_ID = os.getenv("CHAT_ID")
-import os
 
 
 def send_conversion_signals(signals):


### PR DESCRIPTION
## Summary
- fix tuple return when there are no predictions
- provide clear Telegram message when no conversion signals exist
- remove dotenv loading from `binance_api` and `telegram_sender`

## Testing
- `pytest -q` *(fails: APIError - service unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6851556736d88329874914abe3a714ae