### PR TITLE
Fix API key loading via config

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from typing import List, Dict
 
 logger = logging.getLogger(__name__)
-ALERTS_FILE = os.getenv("ALERTS_FILE", "pending_alerts.json")
+ALERTS_FILE = "pending_alerts.json"
 
 
 def _load_alerts() -> List[Dict]:

--- a/binance_api.py
+++ b/binance_api.py
@@ -34,9 +34,15 @@ from binance.exceptions import BinanceAPIException
 logger = logging.getLogger(__name__)
 TELEGRAM_LOG_PREFIX = "\ud83d\udce1 [BINANCE]"
 
-# Load environment variables from the user's home directory
-BINANCE_API_KEY = os.environ.get("BINANCE_API_KEY")
-BINANCE_SECRET_KEY = os.environ.get("BINANCE_SECRET_KEY")
+from config import (
+    BINANCE_API_KEY,
+    BINANCE_SECRET_KEY,
+    TELEGRAM_TOKEN,
+    CHAT_ID,
+    ADMIN_CHAT_ID,
+)
+
+# Credentials are provided via ``config.py`` on the server.
 BINANCE_BASE_URL = "https://api.binance.com"
 
 # File used to log TP/SL updates
@@ -1060,8 +1066,8 @@ def get_token_value_in_uah(symbol: str) -> float:
 def notify_telegram(message: str) -> None:
     """Send a notification to Telegram if credentials are configured."""
 
-    token = os.getenv("TELEGRAM_TOKEN")
-    chat_id = os.getenv("ADMIN_CHAT_ID", os.getenv("CHAT_ID", ""))
+    token = TELEGRAM_TOKEN
+    chat_id = ADMIN_CHAT_ID or CHAT_ID
     if not token or not chat_id:
         logger.debug("%s Telegram credentials not set", TELEGRAM_LOG_PREFIX)
         return

--- a/config.py
+++ b/config.py
@@ -1,8 +1,15 @@
-import os
-
 # Telegram configuration
-TELEGRAM_TOKEN = os.environ.get("TELEGRAM_TOKEN", "")
-CHAT_ID = int(os.environ.get("CHAT_ID", "0"))
+# These values are populated on the server only and should never be committed
+# with real credentials. They remain here purely as placeholders for local
+# configuration.
+TELEGRAM_TOKEN = ""
+CHAT_ID = 0
+ADMIN_CHAT_ID = 0
+
+# API keys
+BINANCE_API_KEY = ""
+BINANCE_SECRET_KEY = ""
+OPENAI_API_KEY = ""
 
 
 # Thresholds for trading decisions
@@ -11,7 +18,7 @@ MIN_PROB_UP = 0.45
 # Minimum expected profit to consider a token attractive.
 # Reduced to allow generation of signals even with tiny profit
 MIN_EXPECTED_PROFIT = 0.01
-MIN_TRADE_AMOUNT = float(os.environ.get("MIN_TRADE_AMOUNT", 10))  # USDT
+MIN_TRADE_AMOUNT = 10.0  # USDT
 
 # Auto trading loop interval in seconds
-TRADE_LOOP_INTERVAL = int(os.environ.get("TRADE_LOOP_INTERVAL", 3600))
+TRADE_LOOP_INTERVAL = 3600

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -1,9 +1,8 @@
 from typing import Dict, Any
 
 from openai import OpenAI
-import os
+from config import OPENAI_API_KEY
 
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 client = OpenAI(api_key=OPENAI_API_KEY)
 
 

--- a/history.py
+++ b/history.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import List, Dict
 
 logger = logging.getLogger(__name__)
-HISTORY_FILE = os.getenv("HISTORY_FILE", "trade_history.json")
+HISTORY_FILE = "trade_history.json"
 
 
 def _load_history() -> List[Dict]:

--- a/ml_model.py
+++ b/ml_model.py
@@ -12,7 +12,9 @@ from binance_api import _to_usdt_pair, is_symbol_valid
 
 MODEL_PATH = "model.joblib"
 
-client = Client(api_key=os.getenv("BINANCE_API_KEY"), api_secret=os.getenv("BINANCE_API_SECRET"))
+from config import BINANCE_API_KEY, BINANCE_SECRET_KEY
+
+client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_SECRET_KEY)
 
 def load_model():
     if os.path.exists(MODEL_PATH):

--- a/ml_screener.py
+++ b/ml_screener.py
@@ -1,13 +1,13 @@
-import os
 from typing import List, Dict
 from binance.client import Client
+from config import BINANCE_API_KEY, BINANCE_SECRET_KEY
 
 from binance_api import get_symbol_price, get_candlestick_klines as get_klines
 import numpy as np
 from ml_model import load_model, generate_features, predict_prob_up
 from utils import dynamic_tp_sl, calculate_expected_profit
 
-client = Client(api_key=os.getenv("BINANCE_API_KEY"), api_secret=os.getenv("BINANCE_API_SECRET"))
+client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_SECRET_KEY)
 
 
 def get_valid_symbols() -> List[str]:

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,6 +1,5 @@
 """Telegram bot configuration and handlers."""
 
-import os
 import logging
 import datetime
 from aiogram import Bot, Dispatcher, types
@@ -56,10 +55,9 @@ from binance_api import (
 )
 from alerts import check_daily_alerts
 
-take_profit_cb = CallbackData("tp", "symbol", "amount")
+from config import TELEGRAM_TOKEN, ADMIN_CHAT_ID
 
-TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
-ADMIN_CHAT_ID = int(os.getenv("ADMIN_CHAT_ID", os.getenv("CHAT_ID", "0")))
+take_profit_cb = CallbackData("tp", "symbol", "amount")
 
 bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher(bot)

--- a/train_model.py
+++ b/train_model.py
@@ -8,10 +8,9 @@ import numpy as np
 import os
 import time
 import subprocess
+from config import BINANCE_API_KEY, BINANCE_SECRET_KEY
 
-api_key = os.getenv("BINANCE_API_KEY")
-api_secret = os.getenv("BINANCE_API_SECRET")
-client = Client(api_key=api_key, api_secret=api_secret)
+client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_SECRET_KEY)
 
 
 def get_all_usdt_symbols(min_volume=500000):


### PR DESCRIPTION
## Summary
- remove usage of `os.getenv` and `.env` style variables
- keep all credentials in `config.py`
- refactor Binance/OpenAI/Telegram helpers to read from `config`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851614a97a483298fce643aebeaae96