### PR TITLE
Remove env usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ pip install --no-cache-dir --force-reinstall aiohttp
 ```bash
 pip install -r requirements.txt
 ```
+
+5. Заповніть `config.py` своїми ключами API. Всі модулі імпортують токени безпосередньо з цього файлу без використання змінних середовища.
+   Не використовуйте змінні середовища або `.env`. Бот читає ключі лише з `config.py`.


### PR DESCRIPTION
## Summary
- document that all tokens come from `config.py` and environment variables aren't used

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685163a812988329beb9085b48153516