### PR TITLE
Remove env variables

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from typing import List, Dict
 
 logger = logging.getLogger(__name__)
-ALERTS_FILE = os.getenv("ALERTS_FILE", "pending_alerts.json")
+ALERTS_FILE = "pending_alerts.json"
 
 
 def _load_alerts() -> List[Dict]:

--- a/binance_api.py
+++ b/binance_api.py
@@ -33,8 +33,12 @@ from binance.exceptions import BinanceAPIException
 logger = logging.getLogger(__name__)
 TELEGRAM_LOG_PREFIX = "\ud83d\udce1 [BINANCE]"
 
-BINANCE_API_KEY = os.getenv("BINANCE_API_KEY")
-BINANCE_SECRET_KEY = os.getenv("BINANCE_SECRET_KEY")
+from config import (
+    BINANCE_API_KEY,
+    BINANCE_SECRET_KEY,
+    TELEGRAM_TOKEN,
+    CHAT_ID,
+)
 BINANCE_BASE_URL = "https://api.binance.com"
 
 # File used to log TP/SL updates
@@ -185,12 +189,12 @@ def get_binance_balances() -> Dict[str, float]:
 
     try:
         temp_client = Client(
-            os.getenv("BINANCE_API_KEY"),
-            os.getenv("BINANCE_SECRET_KEY"),
+            BINANCE_API_KEY,
+            BINANCE_SECRET_KEY,
         )
 
         logging.debug(
-            f"[DEBUG] API: {os.getenv('BINANCE_API_KEY')[:8]}..., SECRET: {os.getenv('BINANCE_SECRET_KEY')[:8]}..."
+            f"[DEBUG] API: {BINANCE_API_KEY[:8]}..., SECRET: {BINANCE_SECRET_KEY[:8]}..."
         )
 
         try:
@@ -789,8 +793,8 @@ def get_token_value_in_uah(symbol: str) -> float:
 def notify_telegram(message: str) -> None:
     """Send a notification to Telegram if credentials are configured."""
 
-    token = os.getenv("TELEGRAM_TOKEN")
-    chat_id = os.getenv("ADMIN_CHAT_ID", os.getenv("CHAT_ID", ""))
+    token = TELEGRAM_TOKEN
+    chat_id = CHAT_ID
     if not token or not chat_id:
         logger.debug("%s Telegram credentials not set", TELEGRAM_LOG_PREFIX)
         return

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -382,13 +382,7 @@ def filter_fallback_best_candidates(candidates, max_results=3):
 if __name__ == "__main__":
     import asyncio
     from telegram import Bot
-    import os
+    from config import TELEGRAM_TOKEN, CHAT_ID
 
-    TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
-    CHAT_ID = os.getenv("CHAT_ID")
-
-    if TELEGRAM_TOKEN and CHAT_ID:
-        bot = Bot(token=TELEGRAM_TOKEN)
-        asyncio.run(daily_analysis_task(bot, int(CHAT_ID)))
-    else:
-        print("❌ TELEGRAM_TOKEN або CHAT_ID не встановлено")
+    bot = Bot(token=TELEGRAM_TOKEN)
+    asyncio.run(daily_analysis_task(bot, int(CHAT_ID)))

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -1,9 +1,8 @@
 from typing import Dict, Any
 
 from openai import OpenAI
-import os
+from config import OPENAI_API_KEY
 
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 client = OpenAI(api_key=OPENAI_API_KEY)
 
 

--- a/history.py
+++ b/history.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import List, Dict
 
 logger = logging.getLogger(__name__)
-HISTORY_FILE = os.getenv("HISTORY_FILE", "trade_history.json")
+HISTORY_FILE = "trade_history.json"
 
 
 def _load_history() -> List[Dict]:

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,6 +1,5 @@
 """Telegram bot configuration and handlers."""
 
-import os
 import logging
 from aiogram import Bot, Dispatcher, types
 from aiogram.dispatcher.filters import Command, Text
@@ -57,8 +56,9 @@ from alerts import check_daily_alerts
 
 take_profit_cb = CallbackData("tp", "symbol", "amount")
 
-TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
-ADMIN_CHAT_ID = int(os.getenv("ADMIN_CHAT_ID", os.getenv("CHAT_ID", "0")))
+from config import TELEGRAM_TOKEN, CHAT_ID
+
+ADMIN_CHAT_ID = int(CHAT_ID)
 
 bot = Bot(token=TELEGRAM_TOKEN)
 dp = Dispatcher(bot)


### PR DESCRIPTION
## Summary
- load API keys and config directly from `config.py`
- avoid any os.getenv lookups for alerts and history
- use config settings when sending Telegram notifications

## Testing
- `python -m compileall -q gpt_utils.py binance_api.py telegram_bot.py alerts.py history.py daily_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_685166953eb883299ab6433457050827