### PR TITLE
Add telegram service module

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,6 @@
 ```bash
 git clone https://github.com/wooferOS/telegram-crypto-bot-github.git
 ```
+
+## ⚠️ Відомі проблеми
+- Binance Convert Small Balances API поки закритий для більшості користувачів. При спробі виклику `convert_dust_to_usdt` бібліотека Binance може видавати `AssertionError: API Secret required for private endpoints`.

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+from .telegram_service import send_messages

--- a/services/telegram_service.py
+++ b/services/telegram_service.py
@@ -1,0 +1,8 @@
+from aiogram import Bot
+from config import TELEGRAM_TOKEN
+
+async def send_messages(chat_id: int, text: str) -> None:
+    """Send a text message via Telegram using the global token."""
+
+    bot = Bot(token=TELEGRAM_TOKEN)
+    await bot.send_message(chat_id, text)


### PR DESCRIPTION
## Summary
- add a simple `telegram_service` using TELEGRAM_TOKEN
- document Binance Convert API issue

## Testing
- `pip install -r requirements.txt` *(fails: Failed to build aiohttp)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6851691975908329981d21bea51dc2e3