### PR TITLE
Fix Telegram token usage

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,5 +2,5 @@
 
 # Позначення Telegram GPT Bot як Python-пакету
 
-# Environment variables are loaded in individual modules
-# where required (for example ``binance_api.py``).
+# All API keys and tokens are imported directly from ``config.py``.
+# No environment variables are used anywhere in the package.


### PR DESCRIPTION
## Summary
- clarify secrets source in `__init__.py`

## Testing
- `python3 -m py_compile auto_trade_cycle.py services/telegram_service.py binance_api.py telegram_bot.py gpt_utils.py daily_analysis.py`
- `pip install -r requirements.txt` *(fails: Failed to build aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_6851742141c883299ab7d85f5dc25a76