### PR TITLE
Remove ping argument from Binance client

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -117,8 +117,8 @@ else:
 
 
 
-# Initialise global Binance client exactly as in Binance docs without pinging
-client = Client(BINANCE_API_KEY, BINANCE_SECRET_KEY, ping=False)
+# Initialise global Binance client exactly as in Binance docs
+client = Client(BINANCE_API_KEY, BINANCE_SECRET_KEY)
 
 # Set of currently tradable USDT pairs
 VALID_PAIRS: set[str] = set()
@@ -297,7 +297,7 @@ def get_binance_balances() -> Dict[str, float]:
     """Return available balances with automatic API diagnostics."""
 
     try:
-        temp_client = Client(BINANCE_API_KEY, BINANCE_SECRET_KEY, ping=False)
+        temp_client = Client(BINANCE_API_KEY, BINANCE_SECRET_KEY)
 
         if BINANCE_API_KEY and BINANCE_SECRET_KEY:
             logging.debug(


### PR DESCRIPTION
## Summary
- fix initialization of Binance Client

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685189f10af8832981f4be5523d9d039