### PR TITLE
Ensure autonomous auto trade cycle

### DIFF
--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -37,7 +37,7 @@ def _store_run_time() -> None:
 if __name__ == "__main__":
     elapsed = _time_since_last_run()
     if elapsed >= TRADE_LOOP_INTERVAL:
-        asyncio.run(main())
+        asyncio.run(main(int(CHAT_ID)))
         _store_run_time()
     else:
         minutes = int(elapsed / 60)


### PR DESCRIPTION
## Summary
- pass chat id explicitly to `auto_trade_cycle`
- round conversion amounts to 2-4 decimals
- call new interface from `run_auto_trade`

## Testing
- `python -m py_compile run_auto_trade.py auto_trade_cycle.py services/telegram_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68525f3d0cb48329a040bbeb1adb7235