### PR TITLE
Improve auto trade scoring and spam control

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -541,9 +541,12 @@ async def auto_trade_loop(max_iterations: int = MAX_AUTO_TRADE_ITERATIONS) -> No
                             _compose_failure_message,
                         )
 
-                        _, _, portfolio, predictions, usdt_bal = generate_conversion_signals()
+                        _, _, portfolio, predictions, usdt_bal, ident = generate_conversion_signals()
                         message = _compose_failure_message(
-                            portfolio, predictions, usdt_bal
+                            portfolio,
+                            predictions,
+                            usdt_bal,
+                            identical_profits=ident,
                         )
                         await send_messages(ADMIN_CHAT_ID, [message])
                         with open(NO_USDT_ALERT_FILE, "w") as f:

--- a/test_binance.py
+++ b/test_binance.py
@@ -1,4 +1,9 @@
 import logging
+import os
+import pytest
+
+os.environ["BINANCE_TEST_MODE"] = "1"
+
 from binance_api import (
     get_usdt_balance,
     get_token_balance,


### PR DESCRIPTION
## Summary
- add human-friendly amount formatting for Telegram messages
- filter tokens with identical expected profit values
- report when all expected profits are the same
- support test mode in `binance_api` and update tests
- handle identical profit flag in failure messages

## Testing
- `python -m py_compile binance_api.py auto_trade_cycle.py daily_analysis.py services/telegram_service.py test_binance.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685261973f0083299e539db00850ad4c