### PR TITLE
Fix generate_conversion_signals return tuple

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -76,6 +76,7 @@ def generate_conversion_signals() -> tuple[
     Dict[str, Dict[str, float]],
     float,
     bool,
+    list,
 ]:
     """Analyze portfolio and propose asset conversions.
 
@@ -204,6 +205,7 @@ def generate_conversion_signals() -> tuple[
         predictions,
         balances.get("USDT", 0.0),
         all_equal,
+        [],
     )
 
 
@@ -312,6 +314,7 @@ async def main(chat_id: int) -> None:
         predictions,
         usdt_balance,
         all_equal,
+        _,
     ) = generate_conversion_signals()
     await send_conversion_signals(
         signals,

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -541,7 +541,7 @@ async def auto_trade_loop(max_iterations: int = MAX_AUTO_TRADE_ITERATIONS) -> No
                             _compose_failure_message,
                         )
 
-                        _, _, portfolio, predictions, usdt_bal, ident = generate_conversion_signals()
+                        _, _, portfolio, predictions, usdt_bal, ident, _ = generate_conversion_signals()
                         message = _compose_failure_message(
                             portfolio,
                             predictions,


### PR DESCRIPTION
## Summary
- extend generate_conversion_signals() to return an extra empty list
- update type hints and usage to match new return value

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: Failed building wheel for aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_685267941e348329979a5f9334e976c2