### PR TITLE
Improve dev auto trading

### DIFF
--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -9,6 +9,11 @@ from auto_trade_cycle import main
 from config import TRADE_LOOP_INTERVAL, CHAT_ID
 from services.telegram_service import send_messages
 
+# Minimum allowed interval between automated runs (1 hour)
+MIN_AUTO_TRADE_INTERVAL = 3600
+# Effective interval is the greater of the config value and our minimum
+AUTO_INTERVAL = max(TRADE_LOOP_INTERVAL, MIN_AUTO_TRADE_INTERVAL)
+
 # Timestamp persistence file used to throttle automated runs
 LAST_RUN_FILE = ".last_run.json"
 
@@ -16,13 +21,13 @@ LAST_RUN_FILE = ".last_run.json"
 def _time_since_last_run() -> float:
     """Return seconds elapsed since the previous run."""
     if not os.path.exists(LAST_RUN_FILE):
-        return TRADE_LOOP_INTERVAL + 1
+        return AUTO_INTERVAL + 1
     try:
         with open(LAST_RUN_FILE, "r", encoding="utf-8") as f:
             data = json.load(f)
         last = float(data.get("timestamp", 0))
     except Exception:
-        return TRADE_LOOP_INTERVAL + 1
+        return AUTO_INTERVAL + 1
     return time.time() - last
 
 
@@ -36,10 +41,12 @@ def _store_run_time() -> None:
 
 if __name__ == "__main__":
     elapsed = _time_since_last_run()
-    if elapsed >= TRADE_LOOP_INTERVAL:
+    if elapsed >= AUTO_INTERVAL:
         asyncio.run(main(int(CHAT_ID)))
         _store_run_time()
     else:
         minutes = int(elapsed / 60)
-        msg = f"Автотрейд-цикл не запущено — останній запуск був {minutes} хвилин тому."
+        msg = (
+            f"Автотрейд-цикл не запущено — останній запуск був {minutes} хвилин тому."
+        )
         asyncio.run(send_messages(int(CHAT_ID), [msg]))

--- a/services/telegram_service.py
+++ b/services/telegram_service.py
@@ -56,10 +56,11 @@ async def send_messages(chat_id: int, messages: Iterable[str], *, min_interval: 
         for text in texts:
             msg_hash = hashlib.md5(text.encode("utf-8")).hexdigest()
             now = time.time()
-            if (
-                msg_hash == _last_data.get("hash")
-                and now - float(_last_data.get("time", 0)) < min_interval
-            ):
+            if msg_hash == _last_data.get("hash"):
+                logger.info("[dev] Duplicate message skipped")
+                continue
+            if now - float(_last_data.get("time", 0)) < min_interval:
+                logger.info("[dev] Message suppressed due to min_interval")
                 continue
             await bot.send_message(chat_id, text)
             _last_data = {"hash": msg_hash, "time": now}


### PR DESCRIPTION
## Summary
- enforce hourly throttling for auto trading
- reduce Telegram spam using message hash logic
- handle invalid Binance API responses gracefully

## Testing
- `python -m py_compile run_auto_trade.py services/telegram_service.py binance_api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6852872e961c8329ac109508a3f24399