### PR TITLE
Improve dev logging

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -583,10 +583,14 @@ def get_symbol_price(pair: str) -> float:
         ticker = _get_client().get_symbol_ticker(symbol=pair)
         return float(ticker["price"])
     except BinanceAPIException as exc:  # pragma: no cover - API errors
-        if "Invalid" in str(exc) or "Signature" in str(exc):
-            logger.warning("[dev] ⛔ %s: %s", pair, exc)
+        msg = str(exc)
+        if "Invalid" in msg:
+            reason = "символ не існує"
+        elif "Signature" in msg:
+            reason = "не пройшла перевірку підпису"
         else:
-            logger.warning("[dev] ❗ Binance API error for %s: %s", pair, exc)
+            reason = msg
+        logger.warning("[dev] ❗ Binance API error for %s: %s", pair, reason)
         return 0.0
     except Exception as e:  # pragma: no cover - network errors
         logger.warning(f"[dev] ❗ Binance API error for {pair}: {e}")

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -550,6 +550,7 @@ async def auto_trade_loop(max_iterations: int = MAX_AUTO_TRADE_ITERATIONS) -> No
                         )
                         message = (
                             "⚠️ Немає USDT для покупки.\n"
+                            "Жоден актив не був проданий або конвертований — баланс не поповнено.\n"
                             f"Причина: {reason}"
                         )
                         await send_messages(ADMIN_CHAT_ID, [message])


### PR DESCRIPTION
## Summary
- refine Binance API error logs with reason analysis
- clarify no-USDT notification text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68529044685483299826cc762193f7cc