### PR TITLE
Log 📊 messages via logger

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -1,6 +1,8 @@
 import asyncio
 import hashlib
 import logging
+
+from log_setup import setup_logging
 import os
 from typing import Dict, List, Optional
 from collections import Counter
@@ -335,5 +337,5 @@ async def main(chat_id: int) -> None:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
+    setup_logging()
     asyncio.run(main(0))

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -374,10 +374,7 @@ def generate_zarobyty_report() -> tuple[str, list, list, str]:
             prob_up = predict_prob_up(model, fv) if model else 0.5
             expected_profit = estimate_profit_debug(symbol)
             logger.info(
-                "\U0001f4ca %s: prob_up=%.2f, expected_profit=%s",
-                symbol,
-                prob_up,
-                expected_profit,
+                f"[dev] \U0001f4ca {symbol}: prob_up={prob_up:.2f}, expected_profit={expected_profit:.4f}"
             )
 
             enriched_tokens.append(
@@ -759,17 +756,16 @@ def demo_candidates_loop(symbols: list[str]) -> list[dict]:
 if __name__ == "__main__":
     import asyncio
     import sys
+    from log_setup import setup_logging
     from services.telegram_service import DevBot
     from config import TELEGRAM_TOKEN, CHAT_ID
 
+    setup_logging()
     if len(sys.argv) > 1 and sys.argv[1] == "demo":
         candidates = demo_candidates_loop(symbols)
         for c in candidates:
             logger.info(
-                "%s: prob_up=%.2f, expected=%s",
-                c["symbol"],
-                c["prob_up"],
-                c["expected_profit"],
+                f"[dev] \U0001f4ca {c['symbol']}: prob_up={c['prob_up']:.2f}, expected_profit={c['expected_profit']:.4f}"
             )
         sys.exit(0)
 

--- a/log_setup.py
+++ b/log_setup.py
@@ -1,0 +1,25 @@
+import logging
+import os
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure root logger to also log to ``logs/trade.log``."""
+    log_path = os.path.join("logs", "trade.log")
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    has_file = any(
+        isinstance(h, logging.FileHandler) and getattr(h, "baseFilename", "").endswith("trade.log")
+        for h in root.handlers
+    )
+    if not has_file:
+        file_handler = logging.FileHandler(log_path, encoding="utf-8")
+        formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+        file_handler.setFormatter(formatter)
+        root.addHandler(file_handler)
+
+    if not any(isinstance(h, logging.StreamHandler) for h in root.handlers):
+        root.addHandler(logging.StreamHandler())
+

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import logging
 import asyncio
+
+from log_setup import setup_logging
 from aiogram import Dispatcher
 from aiogram.utils import executor
 from telegram_bot import (
@@ -18,7 +20,7 @@ from binance_api import get_open_orders
 from daily_analysis import auto_trade_loop
 from config import MAX_MONITOR_ITERATIONS, MAX_AUTO_TRADE_ITERATIONS
 
-logging.basicConfig(level=logging.INFO)
+setup_logging()
 
 
 async def monitor_orders(max_iterations: int = MAX_MONITOR_ITERATIONS) -> None:

--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -5,6 +5,8 @@ import json
 import os
 import time
 
+from log_setup import setup_logging
+
 from auto_trade_cycle import main
 from config import TRADE_LOOP_INTERVAL, CHAT_ID
 from services.telegram_service import send_messages
@@ -40,6 +42,7 @@ def _store_run_time() -> None:
         pass
 
 if __name__ == "__main__":
+    setup_logging()
     elapsed = _time_since_last_run()
     if elapsed >= AUTO_INTERVAL:
         asyncio.run(main(int(CHAT_ID)))

--- a/run_daily_analysis.py
+++ b/run_daily_analysis.py
@@ -1,11 +1,14 @@
 import asyncio
 import sys
 
+from log_setup import setup_logging
+
 from daily_analysis import daily_analysis_task, send_zarobyty_forecast
 from telegram_bot import bot, ADMIN_CHAT_ID
 
 
 if __name__ == "__main__":
+    setup_logging()
     task = sys.argv[1] if len(sys.argv) > 1 else "report"
     if task == "forecast":
         asyncio.run(send_zarobyty_forecast(bot, ADMIN_CHAT_ID))


### PR DESCRIPTION
## Summary
- add `log_setup.py` to configure `logs/trade.log`
- use `setup_logging()` in entry points
- standardize forecast logging with `[dev]` tag

## Testing
- `python -m py_compile log_setup.py daily_analysis.py run_auto_trade.py run_daily_analysis.py main.py auto_trade_cycle.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_685293474fb48329b5afa8d803ca5f3d