### PR TITLE
Update auto trade cycle trigger

### DIFF
--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -9,6 +9,7 @@ from log_setup import setup_logging
 
 from auto_trade_cycle import main
 from config import TRADE_LOOP_INTERVAL, CHAT_ID
+from daily_analysis import generate_zarobyty_report
 from services.telegram_service import send_messages
 
 # Minimum allowed interval between automated runs (1 hour)
@@ -43,6 +44,7 @@ def _store_run_time() -> None:
 
 if __name__ == "__main__":
     setup_logging()
+    generate_zarobyty_report()
     elapsed = _time_since_last_run()
     if elapsed >= AUTO_INTERVAL:
         asyncio.run(main(int(CHAT_ID)))


### PR DESCRIPTION
## Summary
- generate GPT forecast before running auto trades

## Testing
- `python -m py_compile run_auto_trade.py`
- `pip install -r requirements.txt` *(fails: Failed building wheel for aiohttp)*


------
https://chatgpt.com/codex/tasks/task_e_6852cba81d9083298a8d62cb9f98b39c