### PR TITLE
Fix klines timeout and valid pairs

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -27,7 +27,7 @@ from binance_api import (
     market_sell,
     is_symbol_valid,
     get_valid_usdt_symbols,
-    VALID_PAIRS,
+    get_all_valid_symbols,
     refresh_valid_pairs,
 )
 from binance_api import get_candlestick_klines
@@ -67,6 +67,7 @@ from telegram import Bot
 import time
 
 symbols = get_valid_usdt_symbols()
+VALID_PAIRS = get_all_valid_symbols()
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- avoid Binance API hangs by using `requests.get` with timeout in `get_candlestick_klines`
- restore `get_all_valid_symbols` helper
- populate `VALID_PAIRS` via `get_all_valid_symbols` in daily analysis

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6852d433e6388329bc74d37c887fad41