### PR TITLE
Ensure GPT call errors handled and forecast saved

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -468,12 +468,9 @@ def generate_zarobyty_report() -> tuple[str, list, list, str]:
         "strategy": "dev",
     }
     gpt_text = ask_gpt(summary) or ""
-    try:
-        with open("gpt_forecast.txt", "w", encoding="utf-8") as f:
-            f.write(gpt_text)
-        logger.info("GPT forecast saved to gpt_forecast.txt")
-    except OSError:
-        pass
+    with open("gpt_forecast.txt", "w", encoding="utf-8") as f:
+        f.write(gpt_text)
+    logger.info("GPT forecast saved to gpt_forecast.txt")
 
     return report, sell_recommendations, buy_plan, gpt_text
 

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -1,4 +1,6 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional
+
+import logging
 
 from openai import OpenAI
 from config import OPENAI_API_KEY
@@ -6,7 +8,7 @@ from config import OPENAI_API_KEY
 client = OpenAI(api_key=OPENAI_API_KEY)
 
 
-def ask_gpt(summary: Dict[str, Any]) -> str:
+def ask_gpt(summary: Dict[str, Any]) -> Optional[str]:
     """Send trading summary to GPT and return a short strategy forecast."""
     prompt = f"""
     Ти — GPT-аналітик крипторинку. Сформуй три сценарії: агресивний, обережний та fallback.
@@ -27,14 +29,16 @@ def ask_gpt(summary: Dict[str, Any]) -> str:
             model="gpt-4",
             messages=[
                 {"role": "system", "content": "\u0422\u0438 \u0456\u043d\u0432\u0435\u0441\u0442-\u0430\u0441\u0438\u0441\u0442 \u0434\u043b\u044f \u043a\u0440\u0438\u043f\u0442\u043e\u0442\u0440\u0435\u0439\u0434\u0438\u043d\u0433\u0443."},
-                {"role": "user", "content": prompt}
+                {"role": "user", "content": prompt},
             ],
             temperature=0.7,
             max_tokens=500,
+            timeout=15,
         )
         return response.choices[0].message.content.strip()
-    except Exception as e:
-        return f"\u26a0\ufe0f GPT \u043f\u043e\u043c\u0438\u043b\u043a\u0430: {str(e)}"
+    except Exception as e:  # noqa: BLE001
+        logging.warning(f"[dev] GPT error: {e}")
+        return None
 
 
 __all__ = ["ask_gpt"]


### PR DESCRIPTION
## Summary
- add timeout and error logging to `ask_gpt`
- always save GPT forecast file in `generate_zarobyty_report`

## Testing
- `python3 -m py_compile *.py`
- `pip install -q -r requirements.txt` *(failed: build wheel for aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_6852dbebd5048329b971ac841f09875d