### PR TITLE
Implement JSON GPT forecast

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -303,7 +303,7 @@ async def zarobyty_cmd(message: types.Message) -> None:
 
     await message.answer("⏳ Формую звіт...")
 
-    report, _, _, gpt_text = generate_zarobyty_report()
+    report, _, _, forecast = generate_zarobyty_report()
     if not report:
         await message.answer(
             "⚠️ Звіт наразі недоступний. Спробуйте пізніше."
@@ -328,9 +328,14 @@ async def zarobyty_cmd(message: types.Message) -> None:
 
 
     await message.answer(report, parse_mode="Markdown", reply_markup=keyboard)
-    MAX_LEN = 4000
-    for i in range(0, len(gpt_text), MAX_LEN):
-        await message.answer(gpt_text[i:i + MAX_LEN])
+    if forecast is not None:
+        parts = []
+        if forecast.get("buy"):
+            parts.append("🤖 BUY: " + ", ".join(forecast["buy"]))
+        if forecast.get("sell"):
+            parts.append("🤖 SELL: " + ", ".join(forecast["sell"]))
+        if parts:
+            await message.answer("\n".join(parts))
 
 
 def register_handlers(dp: Dispatcher) -> None:


### PR DESCRIPTION
## Summary
- parse GPT forecast as JSON in `gpt_utils.ask_gpt`
- store JSON forecast in daily analysis
- show short forecast in Telegram instead of full text
- load JSON forecast in auto-trade cycle and respect buy/sell lists

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6853e67570748329a258dac95154f00d