### PR TITLE
Relax analysis filters and enrich GPT input

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -82,6 +82,13 @@ def _analyze_pair(pair: str, model) -> Optional[Dict[str, float]]:
         prob_up = 0.5
 
     expected_profit = calculate_expected_profit(price, tp, amount=10, sl_price=sl)
+
+    if expected_profit < 0.001 or prob_up < 0.01:
+        logger.info(
+            f"[dev] ⏭️ Пропускаємо {pair} — expected_profit={expected_profit:.4f}, prob_up={prob_up:.2f}"
+        )
+        return None
+
     return {
         "price": price,
         "tp": tp,

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -434,6 +434,14 @@ def generate_zarobyty_report() -> tuple[str, list, list, dict | None]:
     )
     report_lines.append(f"Загальний баланс: {total_uah}₴\n⸻")
 
+    balance_parts = [
+        f"{t['symbol']}: {t['amount']} ≈ ~{t['uah_value']}₴" for t in token_data
+    ]
+    balance_parts.append(
+        f"USDT: {usdt_balance} ≈ ~{convert_to_uah(usdt_balance)}₴"
+    )
+    balance_str = ", ".join(balance_parts)
+
     report_lines.append("📉 Що продаємо:")
     if sell_recommendations:
         for t in sell_recommendations:
@@ -458,15 +466,21 @@ def generate_zarobyty_report() -> tuple[str, list, list, dict | None]:
         f"💹 Очікуваний прибуток: {expected_profit_usdt} USDT ≈ {expected_profit_uah}₴ за 24г"
     )
 
+    scoreboard = [
+        f"{t['symbol']}: score={t['score']:.4f}"
+        for t in sorted(enriched_tokens, key=lambda x: x['score'], reverse=True)[:3]
+    ]
+
     report = "\n".join(report_lines)
 
     summary = {
-        "balance": available_usdt,
+        "balance": balance_str,
         "sell_candidates": [s.replace("USDT", "") for s in sell_symbols],
         "buy_candidates": [c.replace("USDT", "") for c in candidate_lines],
         "expected_profit": expected_profit_usdt,
         "market_trend": get_sentiment(),
         "strategy": "dev",
+        "scoreboard": scoreboard,
     }
     forecast = ask_gpt(summary)
     if forecast is None:

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -11,9 +11,12 @@ def ask_gpt(summary):
         content = (
             "Ти криптотрейдер. Оціни ситуацію:\n"
             f"- Баланс: {summary.get('balance', '')}\n"
-            f"- Що продаємо: {summary.get('sell', [])}\n"
-            f"- Що купуємо: {summary.get('buy', [])}\n"
-            f"- Очікуваний прибуток: {summary.get('total_profit', '')}\n"
+            f"- Що продаємо: {summary.get('sell') or summary.get('sell_candidates', [])}\n"
+            f"- Що купуємо: {summary.get('buy') or summary.get('buy_candidates', [])}\n"
+            f"- Очікуваний прибуток: {summary.get('total_profit') or summary.get('expected_profit', '')}\n"
+            "scoreboard:\n"
+            + "\n".join(summary.get('scoreboard', []))
+            + "\n"
             "Відповідай строго у форматі JSON, без пояснень:\n"
             '{"buy": [...], "sell": [...], "scores": {...}}'
         )
@@ -21,8 +24,15 @@ def ask_gpt(summary):
         response = client.chat.completions.create(
             model="gpt-4",
             messages=[
-                {"role": "system", "content": "Ти професійний криптотрейдер."},
-                {"role": "user", "content": content}
+                {
+                    "role": "system",
+                    "content": (
+                        "Ти професійний криптотрейдер. "
+                        "Навіть якщо немає великих прибутків, знайди топ-3 монети з потенціалом прибутку, "
+                        "аналізуй дані, а не відповідай шаблоном. Завжди обирай найкращі доступні варіанти."
+                    ),
+                },
+                {"role": "user", "content": content},
             ],
             temperature=0.7,
             timeout=60


### PR DESCRIPTION
## Summary
- relax thresholds in `_analyze_pair`
- expand GPT prompt with extra details and new system guidance
- include formatted balance and a scoreboard when calling GPT

## Testing
- `python3 run_auto_trade.py` *(fails: ModuleNotFoundError: No module named 'aiogram')*
- `tail -n 300 logs/trade.log | grep -Ei "GPT|score|BUY|SELL"`

------
https://chatgpt.com/codex/tasks/task_e_6853ecd2607c8329ab6d9facb23798c8