### PR TITLE
Add adaptive trade filters and metrics

### DIFF
--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -14,6 +14,7 @@ def ask_gpt(summary):
             f"- Що продаємо: {summary.get('sell') or summary.get('sell_candidates', [])}\n"
             f"- Що купуємо: {summary.get('buy') or summary.get('buy_candidates', [])}\n"
             f"- Очікуваний прибуток: {summary.get('total_profit') or summary.get('expected_profit', '')}\n"
+            f"- Адаптивні фільтри: profit>={summary.get('adaptive_filters', {}).get('min_expected_profit')} prob>={summary.get('adaptive_filters', {}).get('min_prob_up')}\n"
             "scoreboard:\n"
             + "\n".join(summary.get('scoreboard', []))
             + "\n"


### PR DESCRIPTION
## Summary
- compute adaptive profit filters in `daily_analysis`
- save adaptive filters in `gpt_forecast.txt`
- include adaptive filter info in GPT prompts
- consider adaptive thresholds and new metrics during conversion analysis

## Testing
- `python -m py_compile daily_analysis.py gpt_utils.py auto_trade_cycle.py`

------
https://chatgpt.com/codex/tasks/task_e_6853eec48b9883298073a14cfb70272a