### PR TITLE
Implement ML-based risk utils and fallback buy logic

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -841,6 +841,4 @@ def demo_candidates_loop(symbols: list[str]) -> list[dict]:
 
 
 if __name__ == "__main__":
-    raise RuntimeError(
-        "🚫 Цей файл не можна запускати напряму. Використовуйте тільки через run_auto_trade.py або systemd."
-    )
+    raise RuntimeError("🚫 Запускати тільки через systemd або run_auto_trade.py")

--- a/ml_utils.py
+++ b/ml_utils.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import numpy as np
+from typing import Dict
+from sklearn.model_selection import TimeSeriesSplit
+from sklearn.metrics import accuracy_score
+from sklearn.base import BaseEstimator
+from ml_model import load_model
+
+
+def predict_proba(symbol: str, indicators: Dict[str, float]) -> float:
+    """Return probability of successful growth using ML model."""
+    model = load_model()
+    if not model:
+        return 0.5
+    try:
+        df = pd.DataFrame([indicators])
+        if hasattr(model, "predict_proba"):
+            proba = model.predict_proba(df)[0][1]
+            return float(proba)
+        pred = model.predict(df)[0]
+        return 1.0 if int(pred) == 1 else 0.0
+    except Exception:
+        return 0.5
+
+
+def walk_forward_validate(model: BaseEstimator, data: pd.DataFrame) -> Dict[str, float]:
+    """Return best parameters via simple walk-forward validation."""
+    tscv = TimeSeriesSplit(n_splits=3)
+    best_score = -1.0
+    best_params: Dict[str, float] = {}
+    params_grid = [
+        {"n_estimators": 100},
+        {"n_estimators": 200},
+    ]
+    for params in params_grid:
+        try:
+            model.set_params(**params)
+        except Exception:
+            continue
+        scores = []
+        for train_idx, test_idx in tscv.split(data):
+            X_train = data.iloc[train_idx].drop(columns=["target"], errors="ignore")
+            y_train = data.iloc[train_idx]["target"]
+            X_test = data.iloc[test_idx].drop(columns=["target"], errors="ignore")
+            y_test = data.iloc[test_idx]["target"]
+            model.fit(X_train, y_train)
+            pred = model.predict(X_test)
+            scores.append(accuracy_score(y_test, pred))
+        mean_score = float(np.mean(scores))
+        if mean_score > best_score:
+            best_score = mean_score
+            best_params = params
+    return best_params

--- a/portfolio_utils.py
+++ b/portfolio_utils.py
@@ -1,0 +1,20 @@
+from typing import Dict, List
+import numpy as np
+import pandas as pd
+
+
+def hierarchical_risk_parity(candidates: List[dict]) -> Dict[str, float]:
+    """Return allocation ratios based on Hierarchical Risk Parity."""
+    if not candidates:
+        return {}
+    symbols = [c["symbol"] for c in candidates]
+    try:
+        data = {c["symbol"]: c.get("history", []) for c in candidates}
+        df = pd.DataFrame(data)
+        corr = df.corr().fillna(0)
+        inv_var = 1 / np.diag(corr.values)
+        weights = inv_var / inv_var.sum()
+        return {sym: float(w) for sym, w in zip(symbols, weights)}
+    except Exception:
+        equal = 1 / len(candidates)
+        return {sym: equal for sym in symbols}

--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import numpy as np
+import ta
+from binance_api import get_candlestick_klines
+
+
+def create_dataset() -> pd.DataFrame:
+    """Generate training dataset and save to ``data/train.csv``."""
+    symbols = ["BTCUSDT", "ETHUSDT"]
+    frames = []
+    for pair in symbols:
+        klines = get_candlestick_klines(pair)
+        if not klines:
+            continue
+        df = pd.DataFrame(
+            klines,
+            columns=[
+                "ts",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "close_time",
+                "qav",
+                "trades",
+                "tb_base",
+                "tb_quote",
+                "ignore",
+            ],
+        ).astype(float)
+        df["rsi"] = ta.momentum.RSIIndicator(close=df["close"]).rsi()
+        macd = ta.trend.MACD(close=df["close"])
+        df["macd"] = macd.macd()
+        bb = ta.volatility.BollingerBands(close=df["close"])
+        df["bb_high"] = bb.bollinger_hband()
+        df["bb_low"] = bb.bollinger_lband()
+        df["vol_change"] = df["volume"].pct_change()
+        df["volatility"] = df["close"].pct_change().rolling(5).std()
+        df["target"] = df["close"].shift(-1) > df["close"]
+        df["symbol"] = pair
+        df.dropna(inplace=True)
+        frames.append(df)
+    dataset = pd.concat(frames, ignore_index=True)
+    dataset.to_csv("data/train.csv", index=False)
+    return dataset
+
+
+if __name__ == "__main__":
+    create_dataset()

--- a/risk_utils.py
+++ b/risk_utils.py
@@ -1,0 +1,29 @@
+from typing import List
+
+
+def calculate_risk_reward(prob_up: float, expected_profit: float) -> float:
+    """Return risk/reward ratio based on ``prob_up`` and ``expected_profit``."""
+    expected_loss = (1 - prob_up) * abs(expected_profit)
+    if expected_loss <= 0:
+        return 0.0
+    return round(expected_profit / expected_loss, 2)
+
+
+def max_drawdown(returns: List[float]) -> float:
+    """Return maximum drawdown for a series of returns."""
+    if not returns:
+        return 0.0
+    peak = returns[0]
+    trough = returns[0]
+    max_dd = 0.0
+    cumulative = 0.0
+    for r in returns:
+        cumulative += r
+        if cumulative > peak:
+            peak = cumulative
+            trough = cumulative
+        if cumulative < trough:
+            trough = cumulative
+            dd = (peak - trough) / max(1e-8, abs(peak))
+            max_dd = max(max_dd, dd)
+    return round(max_dd, 4)

--- a/synthetic_data.py
+++ b/synthetic_data.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import numpy as np
+
+
+def generate_scenarios(data: pd.DataFrame) -> pd.DataFrame:
+    """Add noise or crisis patterns to historical data."""
+    noisy = data.copy()
+    if "close" in noisy:
+        noise = np.random.normal(0, noisy["close"].std() * 0.01, size=len(noisy))
+        noisy["close"] = noisy["close"] + noise
+    # simple crisis pattern
+    if len(noisy) > 10:
+        idx = np.random.randint(0, len(noisy) - 10)
+        noisy.loc[idx : idx + 5, "close"] *= 0.7
+    return noisy


### PR DESCRIPTION
## Summary
- add ML helpers and basic walk-forward validation
- implement risk and portfolio utilities
- create dataset generation and synthetic scenario modules
- enforce systemd-only execution for daily analysis
- extend auto trade cycle with ML probability checks and fallback buy

## Testing
- `python -m py_compile auto_trade_cycle.py daily_analysis.py ml_utils.py risk_utils.py portfolio_utils.py prepare_dataset.py synthetic_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6855013e46708329a93d6f6dd8c16a16