### PR TITLE
Update conversion signal API

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -647,12 +647,7 @@ async def auto_trade_loop(max_iterations: int = MAX_AUTO_TRADE_ITERATIONS) -> No
                         from telegram_bot import ADMIN_CHAT_ID
                         from auto_trade_cycle import generate_conversion_signals
 
-                        _, _, _, predictions, _, _, _ = generate_conversion_signals()
-                        reason = (
-                            "на балансі немає активів з очікуваним прибутком > 0."
-                            if not any(p.get("expected_profit", 0) > 0 for p in predictions.values())
-                            else "невідомо."
-                        )
+                        _, _, _, _, _, _, _ = generate_conversion_signals()
                         # 🔕 [dev] Повідомлення про відсутність USDT більше не надсилається
                         # if usdt_balance < MIN_TRADE_AMOUNT:
                         #     send_telegram_message("⚠️ Немає USDT для покупки.\n")


### PR DESCRIPTION
## Summary
- change generate_conversion_signals to return conversion details and a text report
- adjust callers in main and daily_analysis
- log generated report

## Testing
- `python -m py_compile auto_trade_cycle.py daily_analysis.py`
- `flake8` *(fails: command not found initially, installed then reported many style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68550deb52188329877e8bd853babfff