### PR TITLE
Fix GPT forecast JSON handling

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -541,14 +541,15 @@ def generate_zarobyty_report() -> tuple[str, list, list, dict | None]:
         "scoreboard": scoreboard,
         "adaptive_filters": adaptive_filters,
     }
-    forecast = ask_gpt(summary)
-    if forecast is None:
-        logger.warning("[dev] GPT forecast unavailable")
-    else:
-        forecast = {**forecast, "adaptive_filters": adaptive_filters, "summary": summary}
+    gpt_result = ask_gpt(summary)
+    if gpt_result:
+        forecast = {**gpt_result, "adaptive_filters": adaptive_filters, "summary": summary}
         with open("gpt_forecast.txt", "w", encoding="utf-8") as f:
-            json.dump(forecast, f, ensure_ascii=False)
+            json.dump(forecast, f, indent=2, ensure_ascii=False)
         logger.info("GPT forecast saved to gpt_forecast.txt")
+    else:
+        logger.warning("[dev] ❌ GPT result is empty or invalid.")
+        forecast = gpt_result
 
     return report, sell_recommendations, buy_plan, forecast
 

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -4,10 +4,16 @@ import openai
 from config import OPENAI_API_KEY
 
 client = openai.OpenAI(api_key=OPENAI_API_KEY)
+logger = logging.getLogger(__name__)
+
 
 
 def ask_gpt(summary):
     try:
+        logger.info(
+            f"[dev] ➡️ GPT input:\n{json.dumps(summary, indent=2, ensure_ascii=False)}"
+        )
+
         balance_field = summary.get("balance", "")
         if isinstance(balance_field, dict):
             balance = ", ".join(
@@ -43,16 +49,19 @@ def ask_gpt(summary):
                 },
                 {"role": "user", "content": content},
             ],
-            temperature=0.7,
-            timeout=60
+            temperature=0.2,
+            response_format={"type": "json_object"},
+            timeout=60,
         )
         content = response.choices[0].message.content
         try:
             return json.loads(content)
         except Exception:
-            logging.warning("[dev] GPT response is not JSON, skipping")
-            return None
+            logger.warning(
+                f"[dev] ❌ GPT forecast is not JSON. Raw content:\n{content}"
+            )
+            return {"buy": [], "sell": [], "scores": {}}
 
     except Exception as e:
-        logging.warning(f"[dev] GPT error: {e}")
-        return None
+        logger.warning(f"[dev] GPT error: {e}")
+        return {"buy": [], "sell": [], "scores": {}}


### PR DESCRIPTION
## Summary
- ensure `ask_gpt` logs input, requests JSON and returns fallback object on errors
- log and persist GPT forecast only when result is valid

## Testing
- `pip install -q -r requirements.txt` *(fails: Failed to build installable wheels for some pyproject.toml based projects)*
- `python3 run_daily_analysis.py` *(fails: ModuleNotFoundError: No module named 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_68552eae2e0c8329ad4614fe2fdc5f11