### PR TITLE
Implement updated trading logic and GPT payload

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -531,15 +531,20 @@ def generate_zarobyty_report() -> tuple[str, list, list, dict | None]:
         "min_prob_up": adaptive_min_prob,
     }
 
+    balance_dict = {k: v for k, v in balances.items() if v}
     summary = {
-        "balance": balance_str,
-        "sell_candidates": [s.replace("USDT", "") for s in sell_symbols],
-        "buy_candidates": [c.replace("USDT", "") for c in candidate_lines],
-        "expected_profit": expected_profit_usdt,
+        "balance": balance_dict,
+        "sell": [s.replace("USDT", "") for s in sell_symbols],
+        "buy": [c.replace("USDT", "") for c in candidate_lines],
+        "total_profit": str(expected_profit_usdt),
         "market_trend": get_sentiment(),
-        "strategy": "dev",
-        "scoreboard": scoreboard,
-        "adaptive_filters": adaptive_filters,
+        "filters": {
+            "min_score": 0.3,
+            "min_expected_profit": 0.2,
+            "min_prob_up": 0.45,
+            "min_volatility": 1.0,
+            "min_volume": 10_000_000,
+        },
     }
     gpt_result = ask_gpt(summary)
     if gpt_result:

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -8,32 +8,13 @@ logger = logging.getLogger(__name__)
 
 
 
-def ask_gpt(summary):
+def ask_gpt(payload: dict) -> dict:
+    """Send ``payload`` to GPT and return JSON response."""
+
     try:
         logger.info(
-            f"[dev] ➡️ GPT input:\n{json.dumps(summary, indent=2, ensure_ascii=False)}"
-        )
-
-        balance_field = summary.get("balance", "")
-        if isinstance(balance_field, dict):
-            balance = ", ".join(
-                f"{k}: {v}" for k, v in balance_field.items() if v
-            )
-        else:
-            balance = balance_field
-
-        content = (
-            "Ти криптотрейдер. Оціни ситуацію:\n"
-            f"- Баланс: {balance}\n"
-            f"- Що продаємо: {summary.get('sell') or summary.get('sell_candidates', [])}\n"
-            f"- Що купуємо: {summary.get('buy') or summary.get('buy_candidates', [])}\n"
-            f"- Очікуваний прибуток: {summary.get('total_profit') or summary.get('expected_profit', '')}\n"
-            f"- Адаптивні фільтри: profit>={summary.get('adaptive_filters', {}).get('min_expected_profit')} prob>={summary.get('adaptive_filters', {}).get('min_prob_up')}\n"
-            "scoreboard:\n"
-            + "\n".join(summary.get('scoreboard', []))
-            + "\n"
-            "Відповідай строго у форматі JSON, без пояснень:\n"
-            '{"buy": [...], "sell": [...], "scores": {...}}'
+            "[dev] ➡️ GPT input:\n%s",
+            json.dumps(payload, indent=2, ensure_ascii=False),
         )
 
         response = client.chat.completions.create(
@@ -43,25 +24,23 @@ def ask_gpt(summary):
                     "role": "system",
                     "content": (
                         "Ти професійний криптотрейдер. "
-                        "Навіть якщо немає великих прибутків, знайди топ-3 монети з потенціалом прибутку, "
-                        "аналізуй дані, а не відповідай шаблоном. Завжди обирай найкращі доступні варіанти."
+                        "Завжди поверни JSON з полями buy, sell, scores, summary."
                     ),
                 },
-                {"role": "user", "content": content},
+                {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
             ],
             temperature=0.2,
             response_format={"type": "json_object"},
             timeout=60,
         )
+
         content = response.choices[0].message.content
         try:
             return json.loads(content)
         except Exception:
-            logger.warning(
-                f"[dev] ❌ GPT forecast is not JSON. Raw content:\n{content}"
-            )
-            return {"buy": [], "sell": [], "scores": {}}
+            logger.warning("[dev] ❌ GPT forecast is not JSON. Raw content:\n%s", content)
+            return {"buy": [], "sell": [], "scores": {}, "summary": ""}
 
-    except Exception as e:
-        logger.warning(f"[dev] GPT error: {e}")
-        return {"buy": [], "sell": [], "scores": {}}
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[dev] GPT error: %s", exc)
+        return {"buy": [], "sell": [], "scores": {}, "summary": ""}

--- a/history.py
+++ b/history.py
@@ -28,17 +28,35 @@ def _save_history(data: List[Dict]) -> None:
         logger.error("Failed to save history: %s", exc)
 
 
-def add_trade(symbol: str, side: str, qty: float, price: float, timestamp: str | None = None) -> None:
+def add_trade(
+    symbol: str,
+    side: str,
+    qty: float,
+    price: float,
+    timestamp: str | None = None,
+    *,
+    source: str | None = None,
+    expected_profit: float | None = None,
+    prob_up: float | None = None,
+) -> None:
+    """Persist executed trade to ``trade_history.json``."""
+
     history = _load_history()
-    history.append(
-        {
-            "symbol": symbol,
-            "side": side,
-            "qty": qty,
-            "price": price,
-            "timestamp": timestamp or datetime.utcnow().isoformat(),
-        }
-    )
+    entry: Dict[str, object] = {
+        "symbol": symbol,
+        "action": side.lower(),
+        "amount": qty,
+        "price": price,
+        "timestamp": timestamp or datetime.utcnow().isoformat(),
+    }
+    if source:
+        entry["source"] = source
+    if expected_profit is not None:
+        entry["expected_profit"] = expected_profit
+    if prob_up is not None:
+        entry["prob_up"] = prob_up
+
+    history.append(entry)
     _save_history(history)
 
 


### PR DESCRIPTION
## Summary
- refine GPT request format and add JSON payload
- store trade details with metadata
- calculate trend and volatility weights for scoring
- log trade history for auto trades
- update Telegram summary message
- enable simple backtest mode

## Testing
- `python -m py_compile gpt_utils.py auto_trade_cycle.py run_auto_trade.py daily_analysis.py history.py`
- `python run_auto_trade.py --backtest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685536dbd71c8329b3ff1cecc7130bfc