### PR TITLE
Implement whale alert and trade success ML model

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -1311,6 +1311,21 @@ def get_price_history_24h(symbol: str) -> Optional[List[float]]:
         return None
 
 
+def get_whale_alert(symbol: str, threshold: float = 100_000) -> bool:
+    """Return True if order book contains a single order over ``threshold`` USDT."""
+
+    try:
+        order_book = _get_client().get_order_book(symbol=symbol, limit=100)
+        bids = order_book.get("bids", [])
+        asks = order_book.get("asks", [])
+        max_bid = max([float(qty) * float(price) for price, qty in bids], default=0)
+        max_ask = max([float(qty) * float(price) for price, qty in asks], default=0)
+        return max_bid > threshold or max_ask > threshold
+    except Exception as e:  # pragma: no cover - network errors
+        logger.warning(f"[dev] Whale-check error for {symbol}: {e}")
+        return False
+
+
 def get_candlestick_klines(symbol: str, interval: str = "1h", limit: int = 100) -> List[List[float]]:
     """Return raw candlestick klines for a symbol."""
     url = f"{BINANCE_BASE_URL}/api/v3/klines"


### PR DESCRIPTION
## Summary
- add `get_whale_alert` helper in `binance_api`
- call whale filter and ML trade success estimator in `_analyze_pair`
- implement RandomForest trade history model utilities in `ml_model`

## Testing
- `python -m py_compile binance_api.py auto_trade_cycle.py ml_model.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_68553aab44c08329bb0f9c76ba670c12