### PR TITLE
Fix OpenAI API key usage

### DIFF
--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -11,8 +11,9 @@ def ask_gpt(prompt_dict: dict, model: str = "gpt-4o") -> dict:
     """Send ``prompt_dict`` to GPT and return the JSON response."""
 
     from openai import OpenAI
+    from config import OPENAI_API_KEY
 
-    client = OpenAI()
+    client = OpenAI(api_key=OPENAI_API_KEY)
 
     try:
         kwargs = {


### PR DESCRIPTION
## Summary
- initialise OpenAI client with explicit key from `config.py`

## Testing
- `pip install -r requirements.txt` *(fails: Failed to build wheels for aiohttp)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6855558f12f48329b49cac905840d5f4