### PR TITLE
Fix Binance client init and balance check

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -109,8 +109,8 @@ else:
 
 
 
-# Initialise Binance client lazily to avoid network calls during import
-client: Client | None = None
+# Initialise Binance client explicitly using credentials from ``config.py``
+client: Client = Client(BINANCE_API_KEY, BINANCE_SECRET_KEY, ping=not TEST_MODE)
 
 
 def _get_client() -> Client:
@@ -563,6 +563,9 @@ def convert_to_usdt(asset: str, amount: float):
 
 def get_account_balances() -> Dict[str, Dict[str, str]]:
     """Return mapping of tradable assets to their free and locked amounts."""
+
+    if not client:
+        raise ValueError("[BINANCE] ❌ Binance client not initialized")
 
     try:
         account = client.get_account()

--- a/run_daily_analysis.py
+++ b/run_daily_analysis.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 
 from log_setup import setup_logging
+from binance_api import get_account_balances
 
 from daily_analysis import daily_analysis_task, send_zarobyty_forecast
 from telegram_bot import bot, ADMIN_CHAT_ID
@@ -9,6 +10,12 @@ from telegram_bot import bot, ADMIN_CHAT_ID
 
 if __name__ == "__main__":
     setup_logging()
+
+    balances = get_account_balances()
+    if not balances:
+        print("[dev] ❌ Баланси порожні або API недоступне")
+        sys.exit(1)
+
     task = sys.argv[1] if len(sys.argv) > 1 else "report"
     if task == "forecast":
         asyncio.run(send_zarobyty_forecast(bot, ADMIN_CHAT_ID))


### PR DESCRIPTION
## Summary
- initialize Binance client from config with ping disabled in test mode
- verify client before accessing balances
- exit run_daily_analysis when balances are empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68555c8e566883299c1d3b441fc531f6