### PR TITLE
Fix Binance client initialization

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -110,7 +110,10 @@ else:
 
 
 # Initialise Binance client explicitly using credentials from ``config.py``
-client: Client = Client(BINANCE_API_KEY, BINANCE_SECRET_KEY, ping=not TEST_MODE)
+client: Client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_SECRET_KEY)
+
+if not TEST_MODE:
+    client.ping()
 
 
 def _get_client() -> Client:


### PR DESCRIPTION
## Summary
- use keyword arguments when creating `Client`
- ping Binance separately when not in test mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68555f0329808329831c88b1ab8686e6