### PR TITLE
fix: продаж і покупка доповнені логуванням, TP/SL, а також повідомленням, якщо трейд-цикл не виконав жодної дії.

### DIFF
--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -95,6 +95,15 @@ if __name__ == "__main__":
     elapsed = _time_since_last_run()
     if elapsed >= AUTO_INTERVAL:
         summary = asyncio.run(main(int(CHAT_ID)))
+        if not summary["sold"] and not summary["bought"]:
+            asyncio.run(
+                send_messages(
+                    int(CHAT_ID),
+                    [
+                        "[dev] ❗ Увага: жодного продажу чи купівлі не відбулося. Можливо, не спрацювали фільтри."
+                    ],
+                )
+            )
         _store_run_time()
         lines = ["[dev] 🧾 Звіт:"]
         if summary.get("sold"):


### PR DESCRIPTION
## Summary
- add TP/SL order helpers to trade cycle imports
- log attempts to sell and record sell summary when successful
- create take-profit and stop-loss orders for buys
- notify if nothing was sold or bought in a trade cycle

## Testing
- `python -m py_compile auto_trade_cycle.py run_auto_trade.py`

------
https://chatgpt.com/codex/tasks/task_e_685590d459a48329be6e736535454b67