### PR TITLE
fix: ensure selling and buying real assets on trade cycle

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -31,6 +31,7 @@ from binance_api import (
     get_token_balance,
     place_take_profit_order,
     place_stop_loss_order,
+    VALID_PAIRS,
 )
 from ml_model import (
     load_model,
@@ -780,6 +781,26 @@ async def main(chat_id: int) -> dict:
     }
 
     usdt_before = get_binance_balances().get("USDT", 0.0)
+
+    balances = get_binance_balances()
+    for symbol, amount in balances.items():
+        if symbol == "USDT":
+            continue
+        usdt_pair = f"{symbol.upper()}USDT"
+        if usdt_pair not in VALID_PAIRS:
+            logger.info(f"[dev] ⏭ {symbol} не торгується на Binance — пропускаємо")
+            continue
+
+        logger.info(f"[dev] 🔻 Спроба продати {amount:.6f} {symbol}")
+        result = sell_asset(usdt_pair, amount)
+
+        if result.get("status") == "success":
+            logger.info(f"[dev] ✅ Продано {amount:.6f} {symbol}")
+        elif result.get("status") == "converted":
+            logger.info(f"[dev] 🔁 Конвертовано {symbol} у USDT")
+        else:
+            logger.warning(f"[dev] ⚠️ Не вдалося продати або конвертувати {symbol}, пропускаємо")
+            continue
 
     (
         conversion_signals,

--- a/binance_api.py
+++ b/binance_api.py
@@ -734,6 +734,7 @@ def market_buy(symbol: str, usdt_amount: float) -> dict:
     """Ринкова купівля ``symbol`` на вказану суму в USDT."""
 
     try:
+        logger.info(f"[dev] 🔼 Спроба купити {symbol} на {usdt_amount} USDT")
         price_data = client.get_symbol_ticker(symbol=symbol)
         current_price = float(price_data["price"])
 

--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -7,6 +7,8 @@ import os
 import time
 from datetime import datetime
 
+import logging
+
 from log_setup import setup_logging
 
 from auto_trade_cycle import main
@@ -14,6 +16,8 @@ from binance_api import get_symbol_price
 from history import _load_history
 from config import TRADE_LOOP_INTERVAL, CHAT_ID
 from services.telegram_service import send_messages
+
+logger = logging.getLogger(__name__)
 
 # Minimum allowed interval between automated runs (1 hour)
 MIN_AUTO_TRADE_INTERVAL = 3600
@@ -96,6 +100,7 @@ if __name__ == "__main__":
     if elapsed >= AUTO_INTERVAL:
         summary = asyncio.run(main(int(CHAT_ID)))
         if not summary["sold"] and not summary["bought"]:
+            logger.warning("[dev] ❗ Увага: трейд-цикл завершився без активних дій")
             asyncio.run(
                 send_messages(
                     int(CHAT_ID),


### PR DESCRIPTION
## Summary
- refresh VALID_PAIRS import in auto trade cycle
- liquidate all non-USDT assets before generating buy signals
- log every market buy attempt
- warn when an automated trade cycle performs no actions

## Testing
- `python -m py_compile auto_trade_cycle.py run_auto_trade.py binance_api.py`
- `pip install -r requirements.txt` *(fails: Failed to build aiohttp)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6855a20c52948329ac1e841eb6aeb755