### PR TITLE
Fix VALID_PAIRS refresh for auto trade

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -202,7 +202,7 @@ def get_exchange_info_cached() -> Dict[str, object]:
 
     if os.path.exists(EXCHANGE_INFO_CACHE):
         mtime = os.path.getmtime(EXCHANGE_INFO_CACHE)
-        if time.time() - mtime < EXCHANGE_INFO_TTL:
+        if time.time() - mtime < EXCHANGE_INFO_TTL and "BTTCUSDT" in open(EXCHANGE_INFO_CACHE).read():
             with open(EXCHANGE_INFO_CACHE, "r", encoding="utf-8") as f:
                 return json.load(f)
 

--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -17,12 +17,19 @@ from auto_trade_cycle import (
     load_gpt_filters,
     sell_unprofitable_assets,
 )
-from binance_api import get_symbol_price, get_binance_balances
+from binance_api import (
+    get_symbol_price,
+    get_binance_balances,
+    refresh_valid_pairs,
+)
 from history import _load_history
 from config import TRADE_LOOP_INTERVAL, CHAT_ID
 from services.telegram_service import send_messages
 
 logger = logging.getLogger(__name__)
+
+# Ensure VALID_PAIRS is up to date before trading begins
+refresh_valid_pairs()
 
 # Minimum allowed interval between automated runs (1 hour)
 MIN_AUTO_TRADE_INTERVAL = 3600


### PR DESCRIPTION
## Summary
- refresh VALID_PAIRS on startup of `run_auto_trade.py`
- optionally refresh cached exchange info if BTTC pair missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_685647537e8c8329a340db61b69403ff