### PR TITLE
Improve sell_unprofitable_assets logging

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -514,7 +514,6 @@ def sell_unprofitable_assets(
         logger.info(f"[dev] ✅ SELL виконується: {pair}, кількість: {amount}")
         result = sell_asset(pair, amount)
         status = result.get("status")
-
         if status == "success":
             logger.info(f"[dev] ✅ Продано {amount} {asset} за ринком")
             sold_anything = True
@@ -522,7 +521,10 @@ def sell_unprofitable_assets(
             logger.info(f"[dev] 🔄 Сконвертовано {amount} {asset}")
             sold_anything = True
         else:
-            logger.warning(f"[dev] ⚠️ Не вдалося продати чи сконвертувати {asset}: {result.get('message')}")
+            reason = result.get("message", "невідома помилка")
+            logger.warning(
+                f"[dev] ⚠️ Не вдалося продати або сконвертувати {asset}: {reason}"
+            )
 
         continue  # Завжди продовжувати цикл
 


### PR DESCRIPTION
## Summary
- better logging when selling or converting assets so the exact reason for failure is visible

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68564accf02c8329bfa456ff6a41acc9