### PR TITLE
Fix unpacking of generate_conversion_signals

### DIFF
--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -116,8 +116,6 @@ if __name__ == "__main__":
         _,
         _,
         _,
-        _,
-        _,
         gpt_forecast,
         predictions,
     ) = generate_conversion_signals(gpt_filters, gpt_forecast)


### PR DESCRIPTION
## Summary
- correct return unpacking in `run_auto_trade.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68568a090eb08329a1c95af02c06f29d