### PR TITLE
Fix tuple unpacking in run_auto_trade

### DIFF
--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -116,6 +116,8 @@ if __name__ == "__main__":
         _,
         _,
         _,
+        _,
+        _,
         gpt_forecast,
         predictions,
     ) = generate_conversion_signals(gpt_filters, gpt_forecast)


### PR DESCRIPTION
## Summary
- update call to `generate_conversion_signals` to unpack all returned values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_68568bd7d46c8329ac6f7ff935533041