### PR TITLE
Add warnings suppression to auto trade script

### DIFF
--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -1,5 +1,8 @@
 """Entry point for scheduled auto trade cycle with rate limiting."""
 
+import warnings
+warnings.filterwarnings("ignore", category=UserWarning)
+
 import argparse
 import asyncio
 import json


### PR DESCRIPTION
## Summary
- suppress `UserWarning`s in `run_auto_trade.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `requests`)*

------
https://chatgpt.com/codex/tasks/task_e_68569a4160988329b2c92f622ea83e8c