### PR TITLE
Fix top token filter in auto trade

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -281,7 +281,14 @@ def generate_conversion_signals(
         gpt_notes = []
     ranked.sort(key=lambda x: x[1]["score"], reverse=True)
     all_buy_tokens = ranked
-    top_tokens = ranked[:3]
+
+    top_tokens = [r for r in ranked if r[1]["expected_profit"] > 0 and r[1]["score"] > 0]
+    if not top_tokens:
+        logger.warning("[dev] ⚠️ Жодна монета не пройшла фільтр очікуваного прибутку > 0")
+        top_tokens = ranked[:3]  # fallback: хоча б щось купити
+    else:
+        top_tokens = top_tokens[:3]
+
     logger.info("[dev] \U0001F9EA top_tokens: %s", top_tokens)
     filtered_tokens = top_tokens
 


### PR DESCRIPTION
## Summary
- ensure `top_tokens` isn't empty by picking top ranked tokens when expected profit filter fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6856e1cfb33c8329b0688d4fffa1e980