### PR TITLE
Fix filter_top_tokens return

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -230,6 +230,7 @@ def filter_top_tokens(predictions: dict, limit: int = 3) -> list[tuple[str, dict
     ranked.sort(key=lambda x: x[1]["score"], reverse=True)
     filtered = ranked[:limit]
     logger.info("[dev] 🧪 Після фільтрації: %s", filtered)
+    return filtered
     
 
 def generate_conversion_signals(


### PR DESCRIPTION
## Summary
- fix return value for `filter_top_tokens`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6856e92445288329a3aa5c086136cc4c