### PR TITLE
Improve auto trade buy fallback

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -322,13 +322,14 @@ def generate_conversion_signals(
                 gpt_notes.append(f"⚠️ GPT не рекомендує купувати {sym}")
         top_tokens = filtered_tokens
 
-    if gpt_forecast:
+    # If GPT forecast is available but we already have buy candidates,
+    # ignore the GPT buy list to avoid skipping viable tokens
+    if gpt_forecast and not top_tokens:
         allowed = set(gpt_forecast.get("buy", []))
         filtered = []
-        for pair, data in top_tokens:
+        for pair, data in all_buy_tokens:
             sym = pair.replace("USDT", "")
             if allowed and sym not in allowed:
-                logger.info(f"[dev] ⏭️ GPT блокує покупку {sym}")
                 continue
             filtered.append((pair, data))
         top_tokens = filtered

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -581,6 +581,10 @@ def generate_zarobyty_report() -> tuple[str, list, list, dict | None]:
         logger.warning("[dev] ❌ GPT result is empty or invalid.")
         forecast = gpt_result
 
+    if not buy_plan and buy_candidates:
+        logger.info("⚠️ GPT filter empty — using top buy candidates")
+        buy_plan = sorted(buy_candidates, key=lambda x: x["score"], reverse=True)[:3]
+
     if not buy_plan and forecast and forecast.get("buy"):
         fallback_tokens = forecast["buy"]
         logger.info(


### PR DESCRIPTION
## Summary
- ignore GPT buy list when we already have buying candidates
- fall back to top buy candidates when GPT filter yields nothing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6856ee0dbc248329aafb891e80fd981a