### PR TITLE
Fix token filtering fallback

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -223,13 +223,19 @@ def filter_top_tokens(predictions: dict, limit: int = 3) -> list[tuple[str, dict
     for pair, data in predictions.items():
         ep = data.get("expected_profit", 0.0)
         prob = data.get("prob_up", 0.0)
-        if ep > 0 and prob > 0.5:
-            score = prob * ep
-            ranked.append((pair, {**data, "score": score}))
+        score = prob * ep
+        ranked.append((pair, {**data, "score": score}))
 
     ranked.sort(key=lambda x: x[1]["score"], reverse=True)
     filtered = ranked[:limit]
     logger.info("[dev] 🧪 Після фільтрації: %s", filtered)
+    if not filtered:
+        logger.warning("[dev] ⚠️ Усі токени відфільтровані — використано fallback.")
+
+    if not filtered:
+        logger.warning("[dev] 🛑 Фільтр порожній — fallback на top 3 по score")
+        filtered = sorted(ranked, key=lambda x: x[1]["score"], reverse=True)[:3]
+
     return filtered
     
 

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -583,6 +583,7 @@ def generate_zarobyty_report() -> tuple[str, list, list, dict | None]:
 
     if not buy_plan and buy_candidates:
         logger.info("⚠️ GPT filter empty — using top buy candidates")
+        logger.info("⚠️ GPT не рекомендував жоден токен — використано buy_candidates як fallback")
         buy_plan = sorted(buy_candidates, key=lambda x: x["score"], reverse=True)[:3]
 
     if not buy_plan and forecast and forecast.get("buy"):


### PR DESCRIPTION
## Summary
- adjust token filtering to keep all ranked pairs and fallback if the result is empty
- warn when every token was filtered out
- log that we used buy candidates when GPT suggests none

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails building wheel for aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_6856f00a2e4483298228d283dce06b2d