### PR TITLE
Fix GPT forecast filter handling

### DIFF
--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -80,3 +80,32 @@ def ask_gpt(prompt_dict: dict, model: str = "gpt-4o") -> dict:
         return error_data
 
     return _ensure_structure(parsed)
+
+
+def get_gpt_forecast() -> dict:
+    """Return GPT forecast from ``gpt_forecast.txt``.
+
+    If the file is missing or invalid, an empty forecast structure is
+    returned without raising an exception.
+    """
+
+    empty: dict = {"recommend_buy": [], "do_not_buy": []}
+    try:
+        with open("gpt_forecast.txt", "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as exc:  # pragma: no cover - diagnostics only
+        logger.warning("[dev] Could not read gpt_forecast.txt: %s", exc)
+        return empty
+
+    if not isinstance(data, dict):
+        return empty
+
+    rec_buy = data.get("recommend_buy") or data.get("buy") or []
+    do_not_buy = data.get("do_not_buy") or data.get("sell") or []
+
+    if not isinstance(rec_buy, list):
+        rec_buy = []
+    if not isinstance(do_not_buy, list):
+        do_not_buy = []
+
+    return {"recommend_buy": rec_buy, "do_not_buy": do_not_buy}

--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -113,7 +113,10 @@ if __name__ == "__main__":
 
     # Sell assets with low expected profit before running the main cycle
     gpt_forecast = load_gpt_filters()
-    gpt_filters = {"do_not_sell": gpt_forecast.get("sell", [])}
+    gpt_filters = {
+        "do_not_buy": gpt_forecast.get("do_not_buy", []),
+        "recommend_buy": gpt_forecast.get("recommend_buy", []),
+    }
     (
         _,
         _,


### PR DESCRIPTION
## Summary
- add `get_gpt_forecast()` helper in `gpt_utils`
- improve `filter_top_tokens` with GPT filtering and fallback
- pass GPT forecast through auto trade cycle
- save GPT forecast as `{recommend_buy, do_not_buy}`
- update CLI scripts to use new forecast keys

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6856f7c563f883299fd45754a337eeed