### PR TITLE
Limit analysis token list to top 60

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -410,13 +410,16 @@ def generate_zarobyty_report() -> tuple[str, list, list, dict | None]:
             fail += 1
     logger.debug("Symbols to analyze: %d success, %d skipped", success, fail)
 
+    symbols_for_analysis = symbols_to_analyze
+    symbols_for_analysis = symbols_for_analysis[:60]
+
     enriched_tokens: list[dict] = []
     buy_candidates: list[dict] = []
     model = load_model()
     if not model:
         logger.warning("\u26a0\ufe0f Модель недоступна")
 
-    for symbol in symbols_to_analyze:
+    for symbol in symbols_for_analysis:
         try:
             feature_vector, _, _ = generate_features(symbol)
             fv = np.asarray(feature_vector).reshape(1, -1)


### PR DESCRIPTION
## Summary
- limit number of symbols processed in `daily_analysis.py` to 60

## Testing
- `python -m py_compile daily_analysis.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6856fd24dc3483299a874bfb868b31c6