### PR TITLE
Enable storing daily predictions

### DIFF
--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -109,3 +109,10 @@ def get_gpt_forecast() -> dict:
         do_not_buy = []
 
     return {"recommend_buy": rec_buy, "do_not_buy": do_not_buy}
+
+
+def save_predictions(predictions: dict) -> None:
+    """Save ``predictions`` to ``logs/predictions.json``."""
+
+    with open("logs/predictions.json", "w") as f:
+        json.dump(predictions, f, indent=2)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -303,7 +303,7 @@ async def zarobyty_cmd(message: types.Message) -> None:
 
     await message.answer("⏳ Формую звіт...")
 
-    report, _, _, forecast = generate_zarobyty_report()
+    report, _, _, forecast, _ = generate_zarobyty_report()
     if not report:
         await message.answer(
             "⚠️ Звіт наразі недоступний. Спробуйте пізніше."


### PR DESCRIPTION
## Summary
- add `save_predictions` helper to gpt utilities
- store predictions to `logs/predictions.json` after running daily analysis
- expose predictions from `generate_zarobyty_report`
- adjust handlers to match new return value
- ensure market analysis only checks the top 60 tokens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6856fe42ac6883299d377ba739e932c2