### PR TITLE
Update auto trade cycle to purchase after sell

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -779,6 +779,14 @@ async def main(chat_id: int) -> dict:
     # 2. Sell portfolio assets then buy with the updated USDT balance
     if usdt_balance > 0 and portfolio_tokens:
         sell_unprofitable_assets(balances, predictions, gpt_forecast)
+        # 🟢 Купити після продажу (оновлений баланс)
+        updated_balances = get_binance_balances()
+        await buy_with_remaining_usdt(
+            updated_balances.get("USDT", 0.0),
+            top_tokens,
+            chat_id=chat_id,
+            gpt_forecast=gpt_forecast,
+        )
         if "update_binance_cache" in globals():
             try:
                 update_binance_cache()  # type: ignore[func-returns-value]


### PR DESCRIPTION
## Summary
- buy top tokens immediately after selling unprofitable assets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6857121230248329985fac4a2c67c591