### PR TITLE
Limit analysis to liquid tokens

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -1539,6 +1539,32 @@ def get_top_tokens(limit: int = 50) -> List[Dict[str, object]]:
         return []
 
 
+def get_top_symbols_by_volume(limit: int = 60) -> list[str]:
+    """Return top symbols by 24h quote volume."""
+
+    url = "https://api.binance.com/api/v3/ticker/24hr"
+    try:
+        response = requests.get(url, timeout=(3, 5))
+        data = response.json()
+        filtered = [
+            item["symbol"]
+            for item in data
+            if item["symbol"].endswith("USDT")
+            and not item["symbol"].startswith(("USD", "BUSD", "TUSD"))
+        ]
+        sorted_pairs = sorted(
+            filtered,
+            key=lambda s: next(
+                (float(i["quoteVolume"]) for i in data if i["symbol"] == s), 0
+            ),
+            reverse=True,
+        )
+        return [s.replace("USDT", "") for s in sorted_pairs[:limit]]
+    except Exception as e:  # pragma: no cover - network errors
+        logger.warning(f"[dev] ⚠️ Failed to fetch top symbols: {e}")
+        return []
+
+
 def is_asset_supported(symbol: str, whitelist: Optional[List[str]] = None) -> bool:
     """Check whether a symbol is supported by the bot."""
 

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -20,6 +20,7 @@ from binance_api import (
     get_candlestick_klines as get_klines,
     get_recent_trades as get_my_trades,
     get_top_tokens,
+    get_top_symbols_by_volume,
     load_tradable_usdt_symbols,
     get_usdt_to_uah_rate,
     place_market_order,
@@ -74,7 +75,8 @@ from telegram import Bot
 
 import time
 
-symbols = get_valid_usdt_symbols()
+# Новий список топ-60 символів для аналізу
+TRADING_SYMBOLS = get_top_symbols_by_volume(limit=60)
 VALID_PAIRS = get_all_valid_symbols()
 
 logger = logging.getLogger(__name__)
@@ -101,7 +103,7 @@ def log_and_telegram(message: str) -> None:
 
 async def get_trading_symbols() -> list[str]:
     """Return list of trading symbols available for analysis."""
-    return get_valid_usdt_symbols()
+    return TRADING_SYMBOLS
 
 
 def split_telegram_message(text: str, chunk_size: int = 4000) -> list[str]:
@@ -397,7 +399,7 @@ async def generate_zarobyty_report() -> tuple[str, list, list, dict | None, dict
     symbols_to_analyze: list[str] = []
     success = 0
     fail = 0
-    for sym in symbols:
+    for sym in TRADING_SYMBOLS:
         pair = sym if sym.endswith("USDT") else f"{sym}USDT"
         if is_symbol_valid(pair):
             symbols_to_analyze.append(pair)


### PR DESCRIPTION
## Summary
- fetch top tokens by volume from Binance API
- analyse only the 60 most liquid pairs in daily analysis

## Testing
- `pytest -q` *(fails: Binance API access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68571a16724c83298a9fc747fced0804