### PR TITLE
Fix auto trade cycle start and summary logging

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -555,6 +555,7 @@ def sell_unprofitable_assets(
         token for token in portfolio if token != "USDT" and token not in top3_symbols
     ]
 
+    sold_tokens: list[str] = []
     for token in to_sell:
         amount = portfolio.get(token, 0.0)
         if amount <= 0:
@@ -564,6 +565,7 @@ def sell_unprofitable_assets(
         result = market_sell(pair, amount)
         if result.get("status") == "success":
             logger.info(f"[dev] ✅ Продано {amount} {token}")
+            sold_tokens.append(token)
         elif result.get("status") == "converted":
             logger.info(f"[dev] 🔄 Сконвертовано {amount} {token}")
         else:
@@ -572,7 +574,7 @@ def sell_unprofitable_assets(
                 f"[dev] ⚠️ Не вдалося продати або сконвертувати {token}: {reason}"
             )
 
-    return to_sell
+    return sold_tokens
 
 
 def _compose_failure_message(
@@ -736,7 +738,7 @@ async def buy_with_remaining_usdt(
             continue
 
     logger.warning(
-        "[dev] ❌ Не вдалося купити жоден токен — завершення трейд-циклу без дій"
+        "[dev] ❌ Не вдалося купити жоден токен — завершення циклу"
     )
     return None
 

--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -26,7 +26,7 @@ from binance_api import (
     refresh_valid_pairs,
 )
 from history import _load_history
-from config import TRADE_LOOP_INTERVAL, CHAT_ID
+from config import TRADE_LOOP_INTERVAL, CHAT_ID, ADMIN_CHAT_ID
 from services.telegram_service import send_messages
 
 logger = logging.getLogger(__name__)
@@ -106,6 +106,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     setup_logging()
+    logger.info("[dev] 🚀 Автоматичний трейдинг запущено")
 
     if args.backtest:
         backtest()
@@ -142,7 +143,7 @@ if __name__ == "__main__":
         summary = {"sold": [], "bought": []}
 
         while attempt < MAX_ATTEMPTS:
-            summary = asyncio.run(main(int(CHAT_ID)))
+            summary = asyncio.run(main(int(ADMIN_CHAT_ID)))
             sold = summary.get("sold")
             bought = summary.get("bought")
             if sold or bought:


### PR DESCRIPTION
## Summary
- log start of auto trading
- run trading cycle using ADMIN_CHAT_ID
- track successful sells
- adjust final no-buy log text

## Testing
- `python -m py_compile run_auto_trade.py auto_trade_cycle.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6857902c43e88329b098fb8d08bfea90