### PR TITLE
Improve auto trade logging and selling

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -551,11 +551,12 @@ def sell_unprofitable_assets(
     )[:3]
     top3_symbols = {p.replace("USDT", "") for p, _ in top3}
 
+    sold_tokens = []
+
     to_sell = [
         token for token in portfolio if token != "USDT" and token not in top3_symbols
     ]
 
-    sold_tokens: list[str] = []
     for token in to_sell:
         amount = portfolio.get(token, 0.0)
         if amount <= 0:
@@ -568,6 +569,7 @@ def sell_unprofitable_assets(
             sold_tokens.append(token)
         elif result.get("status") == "converted":
             logger.info(f"[dev] 🔄 Сконвертовано {amount} {token}")
+            sold_tokens.append(token)
         else:
             reason = result.get("message", "невідома помилка")
             logger.warning(

--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -142,10 +142,16 @@ if __name__ == "__main__":
         attempt = 0
         summary = {"sold": [], "bought": []}
 
+        sold: list[str] | None = []
+        bought: list[str] | None = []
+
         while attempt < MAX_ATTEMPTS:
             summary = asyncio.run(main(int(ADMIN_CHAT_ID)))
             sold = summary.get("sold")
             bought = summary.get("bought")
+            logger.info(
+                f"[dev] Спроба {attempt + 1}: продано: {sold}, куплено: {bought}"
+            )
             if sold or bought:
                 break
             attempt += 1
@@ -166,7 +172,9 @@ if __name__ == "__main__":
             lines.append("\n✅ Завершено успішно.")
             asyncio.run(send_messages(int(CHAT_ID), ["\n".join(lines)]))
         else:
-            logger.warning("[dev] ❗ Досягнуто максимум спроб. Жодна угода не виконана.")
+            logger.warning(
+                "[dev] ❌ Після 5 спроб не вдалося виконати жодної угоди"
+            )
     else:
         minutes = int(elapsed / 60)
         msg = (


### PR DESCRIPTION
## Summary
- update `sell_unprofitable_assets` to log conversions and return sold tokens
- log results of each attempt in `run_auto_trade`
- warn if 5 attempts fail to make trades

## Testing
- `python -m py_compile auto_trade_cycle.py run_auto_trade.py`

------
https://chatgpt.com/codex/tasks/task_e_68579246cca48329b90d61cc99f955e3