### PR TITLE
Fix trade summary clearing

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -778,6 +778,9 @@ async def buy_with_remaining_usdt(
 async def main(chat_id: int) -> dict:
     """Simplified auto-trade cycle relying on daily predictions."""
 
+    from constants import TRADE_SUMMARY
+    TRADE_SUMMARY.clear()
+
     TRADE_SUMMARY["sold"].clear()
     TRADE_SUMMARY["bought"].clear()
 


### PR DESCRIPTION
## Summary
- reset trade summary at the start of `main()`

## Testing
- `python -m py_compile auto_trade_cycle.py`
- `python -m py_compile constants.py`

------
https://chatgpt.com/codex/tasks/task_e_68579c6d16a8832995dbfc7d22909a06