### PR TITLE
Fix report import path

### DIFF
--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -19,8 +19,9 @@ from auto_trade_cycle import (
     generate_conversion_signals,
     load_gpt_filters,
     sell_unprofitable_assets,
-    generate_zarobyty_report,
 )
+
+from daily_analysis import generate_zarobyty_report
 from binance_api import (
     get_symbol_price,
     get_binance_balances,


### PR DESCRIPTION
## Summary
- import `generate_zarobyty_report` from `daily_analysis`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6857a033faf0832980be11e343ceae04