### PR TITLE
Fix GPT messages and refresh pairs

### DIFF
--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -32,6 +32,10 @@ async def ask_gpt(messages: list, api_key: str) -> Optional[str]:
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
+
+    if not isinstance(messages, list):
+        messages = [messages]
+
     payload = {
         "model": "gpt-4o",
         "messages": messages,

--- a/ml_model.py
+++ b/ml_model.py
@@ -37,7 +37,8 @@ def get_klines(symbol: str, interval: str = "1h", limit: int = 1000):
         )
         return data
     except Exception as e:
-        logger.warning(f"[dev] ⚠️ get_klines() failed for {symbol}: {e}")
+        if "Invalid symbol" not in str(e):
+            logger.warning(f"[dev] ⚠️ get_klines() failed for {symbol}: {e}")
         return []
 
 def add_technical_indicators(df):

--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -108,6 +108,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     setup_logging()
+    refresh_valid_pairs()
+    logger.info("[dev] ✅ VALID_PAIRS оновлено")
     logger.info("[dev] 🚀 Автоматичний трейдинг запущено")
 
     if args.backtest:


### PR DESCRIPTION
## Summary
- ensure OpenAI API messages are always a list
- refresh VALID_PAIRS when auto trading starts
- filter `Invalid symbol` messages in `get_klines`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6857a1ec2e6c8329b9967ad7e2862bf3