### PR TITLE
Fix GPT message format

### DIFF
--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -33,7 +33,11 @@ async def ask_gpt(messages: list, api_key: str) -> Optional[str]:
         "Content-Type": "application/json",
     }
 
-    if not isinstance(messages, list):
+    if isinstance(messages, str):
+        messages = [{"role": "user", "content": messages}]
+    elif isinstance(messages, dict):
+        messages = [{"role": "user", "content": json.dumps(messages)}]
+    elif not isinstance(messages, list):
         messages = [messages]
 
     payload = {


### PR DESCRIPTION
## Summary
- build proper user message payload when calling GPT

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6857a42e69448329b9fdde4ed30300a6