### PR TITLE
Fix GPT result handling

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -578,6 +578,13 @@ async def generate_zarobyty_report() -> tuple[str, list, list, dict | None, dict
         "token_scores": predictions,
     }
     gpt_result = await ask_gpt(summary, OPENAI_API_KEY)
+    import json
+
+    try:
+        gpt_result = json.loads(gpt_result)
+    except Exception:
+        logger.warning("[dev] ❌ Неможливо розпарсити GPT відповідь як JSON")
+        gpt_result = {}
     if gpt_result == {}:
         log_and_telegram("[GPT] ⚠️ Порожній прогноз, можливо, сталася помилка")
     if gpt_result:


### PR DESCRIPTION
## Summary
- safeguard daily analysis by parsing GPT responses as JSON

## Testing
- `python -m py_compile daily_analysis.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6857a5db83a48329b21c24793bb78936