### PR TITLE
Centralize secrets access via config

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -11,7 +11,10 @@ from log_setup import setup_logging
 import os
 import warnings
 warnings.filterwarnings("ignore", category=UserWarning)
-from config import MIN_EXPECTED_PROFIT, MIN_PROB_UP
+from config import (
+    MIN_EXPECTED_PROFIT,
+    MIN_PROB_UP,
+)
 from typing import Dict, List, Optional
 from collections import Counter
 from constants import TRADE_SUMMARY

--- a/binance_api.py
+++ b/binance_api.py
@@ -50,7 +50,6 @@ from binance.exceptions import BinanceAPIException
 
 # ``logger`` is provided by utils
 TELEGRAM_LOG_PREFIX = "\ud83d\udce1 [BINANCE]"
-TEST_MODE = os.getenv("BINANCE_TEST_MODE") == "1"
 
 from config import (
     BINANCE_API_KEY,
@@ -58,7 +57,10 @@ from config import (
     TELEGRAM_TOKEN,
     CHAT_ID,
     ADMIN_CHAT_ID,
+    BINANCE_TEST_MODE,
 )
+
+TEST_MODE = BINANCE_TEST_MODE
 
 # Credentials are provided via ``config.py`` on the server.
 BINANCE_BASE_URL = "https://api.binance.com"

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -45,7 +45,6 @@ from config import (
     MIN_TRADE_AMOUNT,
     TRADE_LOOP_INTERVAL,
     MAX_AUTO_TRADE_ITERATIONS,
-    OPENAI_API_KEY,
 )
 from gpt_utils import ask_gpt
 from utils import (
@@ -577,7 +576,7 @@ async def generate_zarobyty_report() -> tuple[str, list, list, dict | None, dict
         },
         "token_scores": predictions,
     }
-    gpt_result = await ask_gpt(summary, OPENAI_API_KEY)
+    gpt_result = await ask_gpt(summary)
     import json
 
     try:

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Optional
 
 from binance_api import notify_telegram
+from config import OPENAI_API_KEY
 
 
 logger = logging.getLogger(__name__)
@@ -24,12 +25,14 @@ def _ensure_structure(data: dict) -> dict:
     return result
 
 
-async def ask_gpt(messages: list, api_key: str) -> Optional[str]:
+async def ask_gpt(messages: list) -> Optional[str]:
+    """Send ``messages`` to OpenAI using the ``OPENAI_API_KEY`` from config."""
+
     import aiohttp
 
     url = "https://api.openai.com/v1/chat/completions"
     headers = {
-        "Authorization": f"Bearer {api_key}",
+        "Authorization": f"Bearer {OPENAI_API_KEY}",
         "Content-Type": "application/json",
     }
 

--- a/main.py
+++ b/main.py
@@ -18,7 +18,10 @@ from telegram_bot import (
 )
 from binance_api import get_open_orders
 from daily_analysis import auto_trade_loop
-from config import MAX_MONITOR_ITERATIONS, MAX_AUTO_TRADE_ITERATIONS
+from config import (
+    MAX_MONITOR_ITERATIONS,
+    MAX_AUTO_TRADE_ITERATIONS,
+)
 
 setup_logging()
 

--- a/ml_model.py
+++ b/ml_model.py
@@ -14,7 +14,10 @@ from binance_api import _to_usdt_pair, is_symbol_valid
 
 MODEL_PATH = "model.joblib"
 
-from config import BINANCE_API_KEY, BINANCE_SECRET_KEY
+from config import (
+    BINANCE_API_KEY,
+    BINANCE_SECRET_KEY,
+)
 
 client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_SECRET_KEY)
 

--- a/ml_screener.py
+++ b/ml_screener.py
@@ -1,6 +1,9 @@
 from typing import List, Dict
 from binance.client import Client
-from config import BINANCE_API_KEY, BINANCE_SECRET_KEY
+from config import (
+    BINANCE_API_KEY,
+    BINANCE_SECRET_KEY,
+)
 
 from binance_api import get_symbol_price, get_candlestick_klines as get_klines
 import numpy as np

--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -28,7 +28,11 @@ from binance_api import (
     refresh_valid_pairs,
 )
 from history import _load_history
-from config import TRADE_LOOP_INTERVAL, CHAT_ID, ADMIN_CHAT_ID
+from config import (
+    TRADE_LOOP_INTERVAL,
+    CHAT_ID,
+    ADMIN_CHAT_ID,
+)
 from services.telegram_service import send_messages
 
 logger = logging.getLogger(__name__)

--- a/services/telegram_service.py
+++ b/services/telegram_service.py
@@ -28,7 +28,9 @@ class DevBot(Bot):
         text = _format_dev_message(text)
         return await super().send_message(chat_id, text, *args, **kwargs)
 
-from config import TELEGRAM_TOKEN
+from config import (
+    TELEGRAM_TOKEN,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -56,7 +56,10 @@ from binance_api import (
 )
 from alerts import check_daily_alerts
 
-from config import TELEGRAM_TOKEN, ADMIN_CHAT_ID
+from config import (
+    TELEGRAM_TOKEN,
+    ADMIN_CHAT_ID,
+)
 
 take_profit_cb = CallbackData("tp", "symbol", "amount")
 

--- a/test_binance.py
+++ b/test_binance.py
@@ -1,8 +1,9 @@
 import logging
-import os
 import pytest
+import binance_api
 
-os.environ["BINANCE_TEST_MODE"] = "1"
+# Enable test mode without environment variables
+binance_api.TEST_MODE = True
 
 from binance_api import (
     get_usdt_balance,

--- a/train_model.py
+++ b/train_model.py
@@ -9,7 +9,10 @@ import os
 import time
 import subprocess
 import logging
-from config import BINANCE_API_KEY, BINANCE_SECRET_KEY
+from config import (
+    BINANCE_API_KEY,
+    BINANCE_SECRET_KEY,
+)
 
 client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_SECRET_KEY)
 


### PR DESCRIPTION
## Summary
- use `OPENAI_API_KEY` from `config` inside `ask_gpt`
- remove environment-based test mode and read `BINANCE_TEST_MODE` from `config`
- standardize `config` imports across modules
- adjust test helper to activate Binance test mode directly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6857a9fc20308329b4ea3db1c6ade4c9