### PR TITLE
Handle bad GPT response in report

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -576,13 +576,16 @@ async def generate_zarobyty_report() -> tuple[str, list, list, dict | None, dict
         },
         "token_scores": predictions,
     }
-    gpt_result = await ask_gpt(summary)
+    gpt_text = await ask_gpt(summary, max_tokens=100)
     import json
 
     try:
-        gpt_result = json.loads(gpt_result)
-    except Exception:
-        logger.warning("[dev] ❌ Неможливо розпарсити GPT відповідь як JSON")
+        gpt_result = json.loads(gpt_text)
+    except json.JSONDecodeError:
+        logger.warning(
+            "[dev] ❌ Неможливо розпарсити GPT відповідь як JSON:\n%s",
+            gpt_text,
+        )
         gpt_result = {}
     if gpt_result == {}:
         log_and_telegram("[GPT] ⚠️ Порожній прогноз, можливо, сталася помилка")


### PR DESCRIPTION
## Summary
- improve safety when parsing GPT replies in `generate_zarobyty_report`
- call `ask_gpt` with a higher `max_tokens` limit

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6857ac860700832993a41f3e5c45281b