### PR TITLE
Support custom max_tokens in ask_gpt

### DIFF
--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -25,7 +25,7 @@ def _ensure_structure(data: dict) -> dict:
     return result
 
 
-async def ask_gpt(messages: list) -> Optional[str]:
+async def ask_gpt(messages: list, max_tokens: int = 1200) -> Optional[str]:
     """Send ``messages`` to OpenAI using the ``OPENAI_API_KEY`` from config."""
 
     import aiohttp
@@ -51,7 +51,7 @@ async def ask_gpt(messages: list) -> Optional[str]:
         "model": "gpt-4o",
         "messages": messages,
         "temperature": 0.4,
-        "max_tokens": 1200,
+        "max_tokens": max_tokens,
     }
 
     try:


### PR DESCRIPTION
## Summary
- add optional `max_tokens` argument to `ask_gpt`
- pass provided `max_tokens` to the OpenAI request

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6857ae0e400c8329887f40c88d1da74d