### PR TITLE
Enhance GPT summary and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ pip install --no-cache-dir --force-reinstall aiohttp
 ```bash
 pip install -r requirements.txt
 ```
+Також переконайтеся, що встановлено основні бібліотеки:
+```bash
+pip install aiohttp openai python-binance numpy scikit-learn
+```
 
 5. Заповніть `config.py` своїми ключами API. Всі модулі імпортують токени безпосередньо з цього файлу без використання змінних середовища.
    Не використовуйте змінні середовища або `.env`. Бот читає ключі лише з `config.py`.

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -25,7 +25,7 @@ def _ensure_structure(data: dict) -> dict:
     return result
 
 
-async def ask_gpt(messages: list, max_tokens: int = 1200) -> Optional[str]:
+async def ask_gpt(messages: list, max_tokens: int = 300) -> Optional[str]:
     """Send ``messages`` to OpenAI using the ``OPENAI_API_KEY`` from config."""
 
     import aiohttp

--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -129,15 +129,8 @@ if __name__ == "__main__":
 
     # Створити predictions.json, якщо він відсутній
     if not os.path.exists("predictions.json"):
-        logger.warning(
-            "[dev] Відсутній predictions.json — генеруємо заново через generate_zarobyty_report()"
-        )
-        try:
-            asyncio.run(generate_zarobyty_report())
-        except Exception as e:
-            logger.warning(
-                f"[dev] Помилка під час створення predictions.json: {e}"
-            )
+        from daily_analysis import generate_zarobyty_report
+        asyncio.run(generate_zarobyty_report())
     (
         _,
         _,


### PR DESCRIPTION
## Summary
- refresh VALID_PAIRS before running daily analysis
- provide clearer GPT prompt with a detailed summary and JSON-only instructions
- log top scored tokens and simplify GPT result parsing
- ensure `predictions.json` is generated before trading
- document required pip packages
- expose `max_tokens` in `ask_gpt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857b1e9fc508329a0bcd40f26031881