### PR TITLE
Refresh VALID_PAIRS before analysis

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -298,6 +298,14 @@ def generate_conversion_signals(
     whether the expected profit was below ``CONVERSION_MIN_EXPECTED_PROFIT``.
     """
 
+    refresh_valid_pairs()
+    logger.info("[dev] ✅ VALID_PAIRS оновлено: %d пар", len(VALID_PAIRS))
+    if not VALID_PAIRS:
+        logger.error(
+            "[dev] ❌ VALID_PAIRS порожній — неможливо отримати дані з Binance"
+        )
+        return [], [], [], [], [], "", gpt_forecast
+
     model = load_model()
     min_profit = gpt_forecast.get("adaptive_filters", {}).get("min_expected_profit", 0.3) if gpt_forecast else 0.3
     min_prob = gpt_forecast.get("adaptive_filters", {}).get("min_prob_up", 0.6) if gpt_forecast else 0.6

--- a/binance_api.py
+++ b/binance_api.py
@@ -129,7 +129,11 @@ else:
 
 
 # Initialise Binance client explicitly using credentials from ``config.py``
-client: Client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_SECRET_KEY)
+client: Client = Client(
+    api_key=BINANCE_API_KEY,
+    api_secret=BINANCE_SECRET_KEY,
+    ping=not BINANCE_TEST_MODE,
+)
 
 if not TEST_MODE:
     client.ping()
@@ -143,14 +147,22 @@ def _get_client() -> Client:
             raise RuntimeError("Binance client unavailable in test mode")
         if not BINANCE_API_KEY or not BINANCE_SECRET_KEY:
             raise RuntimeError("Binance API keys are missing")
-        client = Client(BINANCE_API_KEY, BINANCE_SECRET_KEY)
+        client = Client(
+            BINANCE_API_KEY,
+            BINANCE_SECRET_KEY,
+            ping=not BINANCE_TEST_MODE,
+        )
     return client
 
 
 def get_binance_client() -> Client:
     """Return a fresh Binance ``Client`` using credentials from config."""
 
-    return Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_SECRET_KEY)
+    return Client(
+        api_key=BINANCE_API_KEY,
+        api_secret=BINANCE_SECRET_KEY,
+        ping=not BINANCE_TEST_MODE,
+    )
 
 # Set of currently tradable USDT pairs
 VALID_PAIRS: set[str] = set()
@@ -335,7 +347,11 @@ def get_binance_balances() -> Dict[str, float]:
     """Return available balances with automatic API diagnostics."""
 
     try:
-        temp_client = Client(BINANCE_API_KEY, BINANCE_SECRET_KEY)
+        temp_client = Client(
+            BINANCE_API_KEY,
+            BINANCE_SECRET_KEY,
+            ping=not BINANCE_TEST_MODE,
+        )
 
         if BINANCE_API_KEY and BINANCE_SECRET_KEY:
             logger.debug(
@@ -348,7 +364,8 @@ def get_binance_balances() -> Dict[str, float]:
 
         try:
             # Тестовий пінг до Binance
-            temp_client.ping()
+            if not BINANCE_TEST_MODE:
+                temp_client.ping()
             logger.info("✅ Binance API доступний")
 
             account = temp_client.get_account()

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -321,6 +321,12 @@ def calculate_adaptive_filters(days: int = lookback_days) -> tuple[float, float]
 
 async def generate_zarobyty_report() -> tuple[str, list, list, dict | None, dict]:
     refresh_valid_pairs()
+    logger.info("[dev] ✅ VALID_PAIRS оновлено: %d пар", len(VALID_PAIRS))
+    if not VALID_PAIRS:
+        logger.error(
+            "[dev] ❌ VALID_PAIRS порожній — неможливо отримати дані з Binance"
+        )
+        return "", [], [], None, {}
     balances = get_binance_balances()
     usdt_balance = balances.get("USDT", 0) or 0
     now = datetime.datetime.now(pytz.timezone("Europe/Kyiv"))

--- a/run_auto_trade.py
+++ b/run_auto_trade.py
@@ -113,7 +113,12 @@ if __name__ == "__main__":
 
     setup_logging()
     refresh_valid_pairs()
-    logger.info("[dev] ✅ VALID_PAIRS оновлено")
+    logger.info("[dev] ✅ VALID_PAIRS оновлено: %d пар", len(VALID_PAIRS))
+    if not VALID_PAIRS:
+        logger.error(
+            "[dev] ❌ VALID_PAIRS порожній — неможливо отримати дані з Binance"
+        )
+        raise SystemExit(1)
     logger.info("[dev] 🚀 Автоматичний трейдинг запущено")
 
     if args.backtest:


### PR DESCRIPTION
## Summary
- refresh VALID_PAIRS at the start of daily analysis and auto trade
- guard against empty VALID_PAIRS and report how many pairs were loaded
- avoid Binance ping in TEST_MODE

## Testing
- `pip install requests`
- `pip install python-binance`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857b3be4c788329a2f82ba1b1977d27