### PR TITLE
Fix missing refresh_valid_pairs import

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -35,6 +35,7 @@ from binance_api import (
     get_token_balance,
     place_take_profit_order,
     place_stop_loss_order,
+    refresh_valid_pairs,
     VALID_PAIRS,
 )
 from ml_model import (


### PR DESCRIPTION
## Summary
- fix missing import in `auto_trade_cycle.py`

## Testing
- `pytest -q` *(fails: Binance API blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857bee0a6c88329a825e7059582b525