### PR TITLE
Initialize TRADE_SUMMARY before trade cycle

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -791,10 +791,13 @@ async def main(chat_id: int) -> dict:
     """Simplified auto-trade cycle relying on daily predictions."""
 
     from constants import TRADE_SUMMARY
-    TRADE_SUMMARY.clear()
+    TRADE_SUMMARY.setdefault("sold", [])
+    TRADE_SUMMARY.setdefault("bought", [])
+    TRADE_SUMMARY.setdefault("errors", [])
 
     TRADE_SUMMARY["sold"].clear()
     TRADE_SUMMARY["bought"].clear()
+    TRADE_SUMMARY["errors"].clear()
 
     try:
         from daily_analysis import generate_zarobyty_report


### PR DESCRIPTION
## Summary
- avoid `KeyError: 'sold'` in `auto_trade_cycle.main`
- ensure all keys exist and clear their lists at the start of each cycle

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6857c0c197a48329bf4302c6e8b96072