### PR TITLE
Fix lot size rounding and limit valid pairs

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -58,7 +58,6 @@ from binance_api import (
 from daily_analysis import split_telegram_message
 from history import add_trade
 import json
-from binance.helpers import round_step_size
 
 # These thresholds are more lenient for manual conversion suggestions
 # Generate signals even for modest opportunities
@@ -744,9 +743,9 @@ async def buy_with_remaining_usdt(
         price = get_symbol_price(pair)
         if price <= 0:
             continue
-        step = get_lot_step(pair)
+        precision = get_lot_step(pair)
         qty = usdt_balance / price
-        qty = round_step_size(qty, step)
+        qty = round(qty, precision)
         min_notional = get_min_notional(pair)
         notional = qty * price
         if notional < min_notional:

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -703,8 +703,10 @@ async def auto_trade_loop(max_iterations: int = MAX_AUTO_TRADE_ITERATIONS) -> No
                 )
                 if amount and amount > 0:
                     try:
-                        step = get_lot_step(symbol)
-                        adjusted_amount = math.floor(amount / step) * step
+                        precision = get_lot_step(symbol)
+                        step_size = 10 ** (-precision)
+                        adjusted_amount = math.floor(amount / step_size) * step_size
+                        adjusted_amount = round(adjusted_amount, precision)
                         result = market_sell(symbol, adjusted_amount)
                         logger.info("✅ Продано %s: %s | %s", symbol, amount, result)
                         if result.get("status") == "success":


### PR DESCRIPTION
## Summary
- limit VALID_PAIRS to 100 symbols
- adjust get_lot_step to return precision digits and add get_min_quantity
- improve market_buy to handle LOT_SIZE errors gracefully
- update sell helpers and analysis scripts to new precision logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6857c98479388329a61c29cd322372aa