### PR TITLE
Fix Decimal import in binance_api

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -30,6 +30,7 @@ import hashlib
 from utils import logger
 from log_setup import setup_logging
 import decimal
+from decimal import Decimal
 import json
 import math
 from datetime import datetime


### PR DESCRIPTION
## Summary
- import `Decimal` from decimal to prevent `NameError`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'binance' / service unavailable)*
- `python run_auto_trade.py --backtest` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_6857cc2da3448329a54e85ce72ea6464