### PR TITLE
Fix trade summary with strict success checks

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -587,6 +587,11 @@ async def handle_buy_callback(callback_query: types.CallbackQuery):
     amount_in_usdt = 10
     try:
         order = market_buy_symbol_by_amount(token, amount_in_usdt)
+        if order.get("status") != "success":
+            await callback_query.message.answer(
+                f"❌ Купівля {token} не вдалася: {order.get('message', 'невідома помилка')}"
+            )
+            return
         price = (
             float(order.get("fills")[0].get("price"))
             if "fills" in order and order.get("fills")


### PR DESCRIPTION
## Summary
- ensure Binance buy API returns `status: success`
- add success checks when converting or buying tokens
- warn and skip failed orders in buy and convert logic
- show buy errors in Telegram bot UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError / BinanceAPIException)*

------
https://chatgpt.com/codex/tasks/task_e_6857d1b400708329afa8a18d3b2803e6