### PR TITLE
Fix Binance filter handling

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -4,6 +4,8 @@ import logging
 
 import math
 import statistics
+from decimal import Decimal
+import decimal
 import numpy as np
 import datetime
 
@@ -750,9 +752,12 @@ async def buy_with_remaining_usdt(
         price = get_symbol_price(pair)
         if price <= 0:
             continue
-        precision = get_lot_step(pair)
-        qty = usdt_balance / price
-        qty = round(qty, precision)
+        lot_info = get_lot_step(pair)
+        step = Decimal(str(lot_info.get("step_size", 1)))
+        precision = abs(step.normalize().as_tuple().exponent)
+        qty = Decimal(str(usdt_balance / price)).quantize(
+            step, rounding=decimal.ROUND_DOWN
+        )
         min_notional = get_min_notional(pair)
         notional = qty * price
         if notional < min_notional:


### PR DESCRIPTION
## Summary
- update `get_lot_step` to return Binance filter info
- validate market orders against filters
- adjust sell helpers and auto trade code to use new step size
- add logging wrapper for `buy_token_market`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*


------
https://chatgpt.com/codex/tasks/task_e_6857d5fd69548329acb72253a5509cbe