### PR TITLE
Add debug log when portfolio empty

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -856,6 +856,9 @@ async def main(chat_id: int) -> dict:
 
     # 1. Buy if only USDT is available
     if usdt_balance > 0 and not portfolio_tokens:
+        logger.info(
+            "[dev] \ud83d\udcb0 Вхід у режим купівлі на весь баланс USDT — portfolio_tokens порожній"
+        )
         await buy_with_remaining_usdt(
             usdt_balance,
             top_tokens,


### PR DESCRIPTION
## Summary
- log when bot enters full USDT buy mode

## Testing
- `python -m py_compile auto_trade_cycle.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'binance')*

------
https://chatgpt.com/codex/tasks/task_e_6857e5ecf9488329aaae6e6691f7c021