### PR TITLE
Add qty rounding log

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -768,6 +768,12 @@ async def buy_with_remaining_usdt(
         step_size = get_lot_step(pair)[1]
         raw_qty = usdt_balance / price
         qty = adjust_qty_to_step(raw_qty, step_size)
+        logger.info(
+            "[dev] 🧮 Коригування qty: raw=%.8f, stepSize=%.10f → final=%.8f",
+            raw_qty,
+            step_size,
+            qty,
+        )
         min_notional = get_min_notional(pair)
         notional = qty * price
 


### PR DESCRIPTION
## Summary
- log qty rounding details in `buy_with_remaining_usdt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6857ec9b62b48329bfdec526be71835e