### PR TITLE
Fix qty rounding and add debug logging

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -857,6 +857,7 @@ def market_buy(symbol: str, usdt_amount: float) -> dict:
         qty = usdt_amount / current_price
         step_size, min_qty = get_lot_step(pair)
         qty_adj = adjust_qty_to_step(qty, step_size, min_qty)
+        logger.debug("[dev] 🧮 qty=%s step=%s adjusted=%s", qty, step_size, qty_adj)
         if qty_adj < min_qty:
             logger.warning(
                 "[dev] ❌ qty %s для %s менше за minQty %s — пропущено",

--- a/utils.py
+++ b/utils.py
@@ -22,19 +22,16 @@ def convert_to_uah(amount_usdt: float) -> float:
     return round(amount_usdt * get_usdt_to_uah_rate(), 2)
 
 
-def adjust_qty_to_step(qty: float, step: float, min_qty: float = 0.0) -> float:
-    """Round ``qty`` down to comply with ``step`` size taking ``min_qty`` into account."""
+def adjust_qty_to_step(qty: float, step_size: float) -> float:
+    """Round ``qty`` down according to ``step_size`` using ``Decimal`` arithmetic."""
 
     from decimal import Decimal, ROUND_DOWN, getcontext
 
     getcontext().prec = 18
-    d_qty = Decimal(str(qty))
-    d_step = Decimal(str(step))
-    d_min = Decimal(str(min_qty))
-    if d_step == 0:
-        return float(d_qty)
-    adjusted = ((d_qty - d_min) // d_step) * d_step + d_min
-    return float(adjusted.quantize(d_step, rounding=ROUND_DOWN))
+    qty_dec = Decimal(str(qty))
+    step_dec = Decimal(str(step_size))
+    adjusted = (qty_dec // step_dec) * step_dec
+    return float(adjusted.quantize(step_dec, rounding=ROUND_DOWN))
 
 
 def calculate_rr(klines: List[List[float]]) -> float:


### PR DESCRIPTION
## Summary
- refactor `adjust_qty_to_step` in utils to use `Decimal`
- log calculated quantity in `market_buy`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_685814d1864483299dcf43fd19252852