### PR TITLE
Fix LOT_SIZE quantity rounding

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -793,9 +793,18 @@ async def buy_with_remaining_usdt(
         price = get_symbol_price(pair)
         if price <= 0:
             continue
-        step_size, min_qty = get_lot_step(pair)
+        step_size = get_lot_step(pair)
+        min_qty = get_min_qty(pair)
         raw_qty = usdt_balance / price
-        qty = adjust_qty_to_step(raw_qty, step_size, min_qty)
+        qty = raw_qty
+        step_tmp = get_lot_step(symbol)
+        qty = adjust_qty_to_step(qty, step_tmp)
+        logger.info(
+            "[dev] 🔢 LOT_SIZE step=%.10f, adjusted_qty=%.10f",
+            step_tmp,
+            qty,
+        )
+        qty = adjust_qty_to_step(qty, step_size, min_qty)
         logger.warning(
             "[dev] DEBUG: qty=%.8f, step_size=%.8f, min_qty=%.8f",
             qty,

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -705,7 +705,7 @@ async def auto_trade_loop(max_iterations: int = MAX_AUTO_TRADE_ITERATIONS) -> No
                 )
                 if amount and amount > 0:
                     try:
-                        step_size, _ = get_lot_step(symbol)
+                        step_size = get_lot_step(symbol)
                         step = Decimal(str(step_size))
                         adjusted_amount = (Decimal(str(amount)) // step) * step
                         adjusted_amount = adjusted_amount.quantize(

--- a/utils.py
+++ b/utils.py
@@ -23,15 +23,19 @@ def convert_to_uah(amount_usdt: float) -> float:
 
 
 def adjust_qty_to_step(qty: float, step_size: float) -> float:
-    """Round ``qty`` down according to ``step_size`` using ``Decimal`` arithmetic."""
+    """Округлює кількість вниз відповідно до stepSize фільтру LOT_SIZE"""
 
-    from decimal import Decimal, ROUND_DOWN, getcontext
+    import decimal
 
-    getcontext().prec = 18
-    qty_dec = Decimal(str(qty))
-    step_dec = Decimal(str(step_size))
-    adjusted = (qty_dec // step_dec) * step_dec
-    return float(adjusted.quantize(step_dec, rounding=ROUND_DOWN))
+    precision = abs(decimal.Decimal(str(step_size)).as_tuple().exponent)
+    adjusted_qty = float(
+        round(
+            decimal.Decimal(qty)
+            - decimal.Decimal(qty) % decimal.Decimal(step_size),
+            precision,
+        )
+    )
+    return adjusted_qty
 
 
 def calculate_rr(klines: List[List[float]]) -> float:


### PR DESCRIPTION
## Summary
- adjust quantity rounding helper in utils
- expose `get_symbol_filters` and update `get_lot_step`
- round qty in auto trade cycle using LOT_SIZE
- update sale logic for new get_lot_step API

## Testing
- `pip install requests`
- `pip install python-binance`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685815fd0cc88329b61ad3ae2930bce6