### PR TITLE
Fix qty rounding to LOT_SIZE

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -831,6 +831,9 @@ async def buy_with_remaining_usdt(
             step_size,
             qty,
         )
+        logger.debug(
+            f"[dev] 🪙 {symbol}: qty={raw_qty}, step_size={step_size}, adjusted_qty={qty}"
+        )
         min_notional = get_min_notional(pair)
         notional = qty * price
 

--- a/utils.py
+++ b/utils.py
@@ -22,20 +22,17 @@ def convert_to_uah(amount_usdt: float) -> float:
     return round(amount_usdt * get_usdt_to_uah_rate(), 2)
 
 
+from decimal import Decimal, ROUND_DOWN
+
+
 def adjust_qty_to_step(qty: float, step_size: float) -> float:
-    """Округлює кількість вниз відповідно до stepSize фільтру LOT_SIZE"""
+    """Округлює qty вниз до кратного step_size згідно фільтра LOT_SIZE"""
 
-    import decimal
-
-    precision = abs(decimal.Decimal(str(step_size)).as_tuple().exponent)
-    adjusted_qty = float(
-        round(
-            decimal.Decimal(qty)
-            - decimal.Decimal(qty) % decimal.Decimal(step_size),
-            precision,
-        )
+    precision = abs(Decimal(str(step_size)).as_tuple().exponent)
+    adjusted_qty = Decimal(str(qty)).quantize(
+        Decimal(str(step_size)), rounding=ROUND_DOWN
     )
-    return adjusted_qty
+    return float(adjusted_qty)
 
 
 def calculate_rr(klines: List[List[float]]) -> float:


### PR DESCRIPTION
## Summary
- improve quantity adjustment with Decimal rounding
- use step size before every order creation
- add per-token debug logging in the trade cycle

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_68581b2a92448329afd86efd24232e33