### PR TITLE
Improve logging for failed buy attempts

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -888,6 +888,12 @@ async def buy_with_remaining_usdt(
         )
         logger.info("[dev] Купівля на залишок: %s — qty=%.6f price=%.6f", symbol, qty, price)
         result = market_buy_symbol_by_amount(symbol, usdt_balance)
+        if result is None:
+            logger.warning(
+                "[dev] ❌ Fallback купівля не вдалася для %s — create_order не виконано",
+                symbol,
+            )
+            continue
 
         if result.get("status") != "success":
             reason = result.get("message", "невідома помилка")
@@ -908,7 +914,12 @@ async def buy_with_remaining_usdt(
             fallback_symbol,
         )
         result = market_buy_symbol_by_amount(fallback_symbol, usdt_balance)
-        if result.get("status") == "success":
+        if result is None:
+            logger.warning(
+                "[dev] ❌ Fallback купівля не вдалася для %s — create_order не виконано",
+                fallback_symbol,
+            )
+        elif result.get("status") == "success":
             TRADE_SUMMARY.get('bought').append(
                 f"Fallback → {fallback_symbol} на {usdt_balance:.2f}"
             )

--- a/binance_api.py
+++ b/binance_api.py
@@ -868,6 +868,14 @@ def market_buy_symbol_by_amount(symbol: str, amount: float) -> Dict[str, object]
                 notional,
                 min_notional,
             )
+            logger.warning(
+                "[dev] ❌ Купівля не відбулась: qty=%.8f < min_qty=%.8f або notional=%.8f < min_notional=%.8f для %s",
+                quantity,
+                min_qty,
+                notional,
+                min_notional,
+                symbol,
+            )
             return {
                 "status": "error",
                 "message": "qty below min_qty",


### PR DESCRIPTION
## Summary
- add detailed warning when amount fails min filters in `market_buy_symbol_by_amount`
- warn when fallback buy attempt in `buy_with_remaining_usdt` returns `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860db43502c8329a992abc8ac306199