### PR TITLE
Fix surrogate emoji log entry

### DIFF
--- a/auto_trade_cycle.py
+++ b/auto_trade_cycle.py
@@ -1019,7 +1019,7 @@ async def main(chat_id: int) -> dict:
     # 1. Buy if only USDT is available
     if usdt_balance > 0 and not portfolio_tokens:
         logger.info(
-            "[dev] \ud83d\udcb0 Вхід у режим купівлі на весь баланс USDT — portfolio_tokens порожній"
+            "[dev] Вхід у режим купівлі на весь баланс USDT — portfolio_tokens порожній"
         )
         await buy_with_remaining_usdt(
             usdt_balance,


### PR DESCRIPTION
## Summary
- remove `💰` emoji from auto_trade_cycle logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686772d7db008329b37ed4ec127d9063