### PR TITLE
Retry buy on NOTIONAL filter failure

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -903,7 +903,7 @@ def market_buy_symbol_by_amount(symbol: str, amount: float) -> Dict[str, object]
                 )
                 break
             except BinanceAPIException as e:
-                if "Insufficient balance" in str(e):
+                if "Insufficient balance" in str(e) or "NOTIONAL" in str(e):
                     quantity *= 0.99
                     quantity = adjust_qty_to_step(quantity, step_size)
                     logger.warning(


### PR DESCRIPTION
## Summary
- handle `Filter failure: NOTIONAL` when buying via `market_buy_symbol_by_amount`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867796edf148329ab9df0f07af9749d