### PR TITLE
Fix market buy error return

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -937,7 +937,7 @@ def market_buy_symbol_by_amount(symbol: str, amount: float) -> Dict[str, object]
         }
     except BinanceAPIException as e:  # pragma: no cover - network errors
         logger.warning("[dev] Binance buy error for %s: %s", pair, e)
-        return {"status": "error", "symbol": symbol, "qty": float(quantity), "error": str(e)}
+        return {"status": "error", "symbol": symbol, "qty": float(quantity), "error": str(e), "order": None}
     except Exception as exc:
         logger.warning("[dev] Unexpected buy error for %s: %s", pair, exc)
         return {"status": "error", "symbol": symbol, "qty": float(quantity), "error": str(exc)}


### PR DESCRIPTION
## Summary
- include `order` key in `market_buy_symbol_by_amount` error return

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678029d9e48329b341184b8203ce0c