### PR TITLE
Implement convert history logging

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -4,6 +4,7 @@ from convert_api import get_quote, accept_quote
 from convert_model import predict
 from convert_filters import check_filters, is_duplicate_conversion
 from convert_logger import log_trade, log_quote, logger
+from convert_logger import log_convert_history
 import json
 from convert_notifier import notify_success, notify_failure
 from config_dev3 import CONVERT_SCORE_THRESHOLD
@@ -13,6 +14,18 @@ def process_pair(from_token: str, to_token: str, amount: float) -> Dict[str, Any
     quote = get_quote(from_token, to_token, amount)
     log_quote(from_token, to_token, quote)
     expected_profit, prob_up, score = predict(from_token, to_token, quote)
+    accepted = score >= CONVERT_SCORE_THRESHOLD
+    log_convert_history({
+        "from_token": from_token,
+        "to_token": to_token,
+        "score": score,
+        "expected_profit": expected_profit,
+        "prob_up": prob_up,
+        "ratio": quote.get("ratio"),
+        "from_amount": quote.get("fromAmount"),
+        "to_amount": quote.get("toAmount"),
+        "accepted": accepted,
+    })
     data = {
         "from": from_token,
         "to": to_token,

--- a/convert_logger.py
+++ b/convert_logger.py
@@ -43,3 +43,29 @@ def log_quote(from_token: str, to_token: str, quote_data: dict) -> None:
     logger.info(
         f"[dev3] \U0001F4E5 Quote {from_token} → {to_token}: {json.dumps(quote_data, indent=2)}"
     )
+
+
+import os
+import json
+from datetime import datetime
+
+
+def log_convert_history(entry: dict):
+    """Append a single convert entry to logs/convert_history.json"""
+    os.makedirs("logs", exist_ok=True)
+    path = "logs/convert_history.json"
+
+    if os.path.exists(path):
+        with open(path, "r") as f:
+            try:
+                history = json.load(f)
+            except json.JSONDecodeError:
+                history = []
+    else:
+        history = []
+
+    entry["timestamp"] = datetime.utcnow().isoformat()
+    history.append(entry)
+
+    with open(path, "w") as f:
+        json.dump(history, f, indent=2)


### PR DESCRIPTION
## Summary
- log each conversion attempt in `logs/convert_history.json`
- call the logger from `process_pair`

## Testing
- `python -m py_compile convert_cycle.py convert_logger.py`

------
https://chatgpt.com/codex/tasks/task_e_686bdffb30388329947c4b77cc5c49c7