### PR TITLE
Enable auto-training after convert cycle

### DIFF
--- a/run_convert_trade.py
+++ b/run_convert_trade.py
@@ -1,6 +1,7 @@
 import os
 import glob
 from typing import List
+import subprocess
 
 from convert_api import get_balances, get_available_to_tokens
 from convert_cycle import process_pair
@@ -43,15 +44,13 @@ def main() -> None:
     cleanup()
     logger.info("[dev3] ✅ Цикл завершено")
 
-    import subprocess
-
-    # 🔁 Автоматичне навчання моделі після завершення циклу
+    # 🧠 Автоматичне навчання моделі
     try:
         logger.info("[dev3] 📚 Починаємо автоматичне навчання моделі...")
         subprocess.run(["python3", "train_convert_model.py"], check=True)
         logger.info("[dev3] ✅ Навчання завершено")
     except Exception as e:
-        logger.warning(f"[dev3] ⚠️ Помилка під час навчання: {e}")
+        logger.warning(f"[dev3] ❌ Помилка навчання моделі: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- trigger training after every convert cycle
- move subprocess import to the top

## Testing
- `python -m py_compile run_convert_trade.py`
- `python -m py_compile train_convert_model.py convert_logger.py convert_api.py convert_cycle.py balance_guard.py convert_filters.py convert_model.py utils_dev3.py convert_notifier.py __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_686bedd5b87c83298b84e37015d79b6a