### PR TITLE
Implement profit model features for dev3

### DIFF
--- a/asian_range.py
+++ b/asian_range.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from binance_api import get_historical_prices
+
+
+def get_asian_range(symbol: str, limit=96) -> tuple[float, float]:
+    """Asian range: 00:00–08:00 UTC → 8 годин, 5-хвилинні свічки = 96 штук"""
+    prices = get_historical_prices(symbol, interval="5m", limit=limit)
+    highs = [candle["high"] for candle in prices]
+    lows = [candle["low"] for candle in prices]
+    return max(highs), min(lows)
+
+
+def is_breakout(symbol: str, price: float) -> bool:
+    high, low = get_asian_range(symbol)
+    return price > high or price < low

--- a/binance_api.py
+++ b/binance_api.py
@@ -1,0 +1,24 @@
+import requests
+
+BASE_URL = "https://api.binance.com"
+
+
+def get_historical_prices(symbol: str, interval: str = "5m", limit: int = 100):
+    url = f"{BASE_URL}/api/v3/klines"
+    params = {"symbol": symbol.upper(), "interval": interval, "limit": limit}
+    response = requests.get(url, params=params, timeout=10)
+    data = response.json()
+    candles = []
+    for item in data:
+        candles.append({
+            "open": float(item[1]),
+            "high": float(item[2]),
+            "low": float(item[3]),
+            "close": float(item[4]),
+        })
+    return candles
+
+
+def get_last_prices(symbol: str, limit: int = 100):
+    candles = get_historical_prices(symbol, limit=limit)
+    return [c["close"] for c in candles]

--- a/convert_logger.py
+++ b/convert_logger.py
@@ -6,24 +6,33 @@ LOG_FILE = os.path.join("logs", "trade_convert.log")
 ERROR_LOG_FILE = os.path.join("logs", "convert_errors.log")
 BALANCE_LOG_FILE = os.path.join("logs", "balance_guard.log")
 
+
 os.makedirs("logs", exist_ok=True)
+formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
 
 logger = logging.getLogger("convert")
 logger.setLevel(logging.INFO)
 
 if not any(isinstance(h, logging.FileHandler) and h.baseFilename.endswith("trade_convert.log") for h in logger.handlers):
     fh = logging.FileHandler(LOG_FILE, encoding="utf-8")
-    fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    fh.setFormatter(formatter)
     logger.addHandler(fh)
 
 if not any(isinstance(h, logging.FileHandler) and h.baseFilename.endswith("convert_errors.log") for h in logger.handlers):
     eh = logging.FileHandler(ERROR_LOG_FILE, encoding="utf-8")
-    eh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    eh.setFormatter(formatter)
     eh.setLevel(logging.WARNING)
     logger.addHandler(eh)
 
 if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
     logger.addHandler(logging.StreamHandler())
+
+# Summary logger for overall cycle results
+summary_logger = logging.getLogger("summary")
+summary_handler = logging.FileHandler("logs/convert_summary.log")
+summary_handler.setFormatter(formatter)
+summary_logger.addHandler(summary_handler)
+summary_logger.setLevel(logging.INFO)
 
 
 def log_trade(data: dict) -> None:

--- a/indicators.py
+++ b/indicators.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+
+def get_rsi(prices: list[float], period: int = 14) -> float:
+    deltas = np.diff(prices)
+    ups = np.where(deltas > 0, deltas, 0)
+    downs = np.where(deltas < 0, -deltas, 0)
+    avg_gain = np.mean(ups[-period:])
+    avg_loss = np.mean(downs[-period:]) or 1e-9
+    rs = avg_gain / avg_loss
+    return 100 - (100 / (1 + rs))
+
+
+def get_macd(prices: list[float]) -> tuple[float, float]:
+    ema12 = np.mean(prices[-12:])
+    ema26 = np.mean(prices[-26:])
+    macd_line = ema12 - ema26
+    signal_line = np.mean([ema12 - ema26 for _ in range(9)])  # просте згладжування
+    return macd_line, signal_line

--- a/run_convert_trade.py
+++ b/run_convert_trade.py
@@ -1,15 +1,12 @@
 import os
 import glob
-from typing import List
 import subprocess
 
 from convert_api import get_balances, get_available_to_tokens
 from convert_cycle import process_pair
 from convert_logger import logger
-from utils_dev3 import load_json, save_json
 from config_dev3 import CONVERT_SCORE_THRESHOLD
 
-HISTORY_FILE = "convert_history.json"
 CACHE_FILES = [
     "signals.txt",
     "last_message.txt",
@@ -34,23 +31,16 @@ def cleanup() -> None:
 def main() -> None:
     logger.info("[dev3] 🔄 Запуск convert трейдингу")
     balances = get_balances()
-    history: List[dict] = load_json(HISTORY_FILE) or []
-    for token, amount in balances.items():
+    for token in balances.keys():
         tos = get_available_to_tokens(token)
-        for to_asset in tos:
-            result = process_pair(token, to_asset, amount)
-            history.append(result)
-    save_json(HISTORY_FILE, history)
+        process_pair(token, tos, None, CONVERT_SCORE_THRESHOLD)
     cleanup()
     logger.info("[dev3] ✅ Цикл завершено")
 
     # 🧠 Автоматичне навчання моделі
-    try:
-        logger.info("[dev3] 📚 Починаємо автоматичне навчання моделі...")
-        subprocess.run(["python3", "train_convert_model.py"], check=True)
-        logger.info("[dev3] ✅ Навчання завершено")
-    except Exception as e:
-        logger.warning(f"[dev3] ❌ Помилка навчання моделі: {e}")
+    logger.info("[dev3] 📚 Починаємо автоматичне навчання моделі...")
+    subprocess.run(["python3", "train_convert_model.py"], check=True)
+    logger.info("[dev3] ✅ Навчання завершено")
 
 
 if __name__ == "__main__":

--- a/train_convert_model.py
+++ b/train_convert_model.py
@@ -36,20 +36,22 @@ def main() -> None:
         print("❌ Недостатньо даних для навчання: accepted == True/False відсутні.")
         return
 
-    X = np.array([
+    X_train = np.array([
         [item.get("score", 0.0), item.get("ratio", 0.0), item.get("inverseRatio", 0.0)]
         for item in history
     ])
     y = np.array([item["accepted"] for item in history])
 
     print(
-        f"✅ Навчання на {len(X)} прикладах ({sum(y)} позитивних, {len(y)-sum(y)} негативних)"
+        f"✅ Навчання на {len(X_train)} прикладах ({sum(y)} позитивних, {len(y)-sum(y)} негативних)"
     )
 
     model = RandomForestRegressor(n_estimators=50)
-    model.fit(X, y)
+    model.fit(X_train, y)
     joblib.dump(model, MODEL_PATH)
     logger.info("Model trained on %d records", len(history))
+    logger.info(f"[dev3] ℹ️ Feature importance: {model.feature_importances_}")
+    logger.info(f"[dev3] Модель навчена на {len(X_train)} прикладах")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement fallback ratio search in `convert_cycle.py`
- add RSI and MACD helpers in `indicators.py`
- detect Asian range breakouts via `asian_range.py`
- extend `convert_model.predict` with technical indicators
- log model training details in `train_convert_model.py`
- trigger automatic training after trades
- introduce `convert_summary.log` via `convert_logger.py`
- add Binance market data helpers

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686caec4c8208329b3d76cdc572c42b0