### PR TITLE
Improve Binance API error handling

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -1,4 +1,5 @@
 import requests
+from convert_logger import logger
 
 BASE_URL = "https://api.binance.com"
 
@@ -6,17 +7,30 @@ BASE_URL = "https://api.binance.com"
 def get_historical_prices(symbol: str, interval: str = "5m", limit: int = 100):
     url = f"{BASE_URL}/api/v3/klines"
     params = {"symbol": symbol.upper(), "interval": interval, "limit": limit}
-    response = requests.get(url, params=params, timeout=10)
-    data = response.json()
-    candles = []
-    for item in data:
-        candles.append({
-            "open": float(item[1]),
-            "high": float(item[2]),
-            "low": float(item[3]),
-            "close": float(item[4]),
-        })
-    return candles
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        data = response.json()
+        if not isinstance(data, list) or not all(
+            isinstance(item, list) and len(item) >= 6 for item in data
+        ):
+            raise ValueError(f"Invalid response from Binance for {symbol}: {data}")
+
+        candles = []
+        for item in data:
+            candles.append(
+                {
+                    "timestamp": int(item[0]),
+                    "open": float(item[1]),
+                    "high": float(item[2]),
+                    "low": float(item[3]),
+                    "close": float(item[4]),
+                    "volume": float(item[5]),
+                }
+            )
+        return candles
+    except Exception as exc:  # pragma: no cover - diagnostics only
+        logger.warning(f"[dev3] \u274c get_historical_prices failed for {symbol}: {exc}")
+        return []
 
 
 def get_last_prices(symbol: str, limit: int = 100):


### PR DESCRIPTION
## Summary
- handle invalid Binance responses in `get_historical_prices`
- log warning when API data can't be parsed

## Testing
- `python -m py_compile binance_api.py asian_range.py balance_guard.py convert_api.py convert_cycle.py convert_filters.py convert_logger.py convert_model.py convert_notifier.py utils_dev3.py run_convert_trade.py train_convert_model.py`


------
https://chatgpt.com/codex/tasks/task_e_686cb1dd72fc8329a1fa2efc94cb17a9