### PR TITLE
Fix training data check and dedup in convert cycle

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -46,6 +46,23 @@ def process_pair(from_token: str, to_tokens: List[str], amount: float, score_thr
     filtered_pairs = filter_top_tokens(all_tokens, score_threshold, top_n=2, fallback_n=1)
     top_results = [(t, data["score"], data["quote"]) for t, data in filtered_pairs]
 
+    # Build opportunities list for post-processing
+    convert_opportunities = [
+        {"from": from_token, "to": t, "score": sc, "quote": q}
+        for t, sc, q in top_results
+    ]
+
+    # 🧹 Remove duplicate 'from' tokens keeping highest score
+    unique_ops = {}
+    for op in convert_opportunities:
+        key = op["from"]
+        if key not in unique_ops or op["score"] > unique_ops[key]["score"]:
+            unique_ops[key] = op
+
+    convert_opportunities = list(unique_ops.values())
+
+    top_results = [(op["to"], op["score"], op["quote"]) for op in convert_opportunities]
+
     # Log selection results
     if top_results:
         logger.info("[dev3] ✅ Обрано токени для купівлі: %s", [t for t, _, _ in top_results])

--- a/train_convert_model.py
+++ b/train_convert_model.py
@@ -33,9 +33,16 @@ def main() -> None:
     # Використовуємо лише останні 500 прикладів
     dataset = dataset[-500:]
 
-    if not dataset:
+    has_true = any(x.get("accepted") is True for x in dataset)
+    has_false = any(x.get("accepted") is False for x in dataset)
+
+    if not has_true and not has_false:
         print("❌ Недостатньо даних для навчання: accepted == True/False відсутні.")
         return
+
+    print(
+        f"🔁 Навчання: accepted=True: {sum(1 for x in dataset if x.get('accepted') is True)}, accepted=False: {sum(1 for x in dataset if x.get('accepted') is False)}"
+    )
 
     X_train = np.array([
         [item.get("score", 0.0), item.get("ratio", 0.0), item.get("inverseRatio", 0.0)]


### PR DESCRIPTION
## Summary
- handle missing `accepted` values more flexibly when training
- ensure convert opportunities are unique per `from` token

## Testing
- `python -m py_compile train_convert_model.py convert_cycle.py`

------
https://chatgpt.com/codex/tasks/task_e_686cd160be748329b119971e5a7733b4