### PR TITLE
Add Binance balance retrieval helper

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -100,3 +100,18 @@ def get_ratio(from_token: str, to_token: str, amount: float = 1.0) -> float:
             f"[dev3] ❌ get_ratio failed for {from_token} → {to_token}: {exc}"
         )
         return 0.0
+
+
+def get_binance_balances() -> dict:
+    """Повертає баланс по всіх доступних токенах."""
+    from binance.client import Client
+    from config_dev3 import BINANCE_API_KEY, BINANCE_SECRET_KEY
+
+    client = Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_SECRET_KEY)
+    account_info = client.get_account()
+    balances = {}
+    for asset in account_info["balances"]:
+        free = float(asset["free"])
+        if free > 0:
+            balances[asset["asset"]] = free
+    return balances


### PR DESCRIPTION
## Summary
- add `get_binance_balances` to `binance_api.py`

## Testing
- `python3 -c "from binance_api import get_binance_balances; print(get_binance_balances())"` *(fails: ModuleNotFoundError: No module named 'config_dev3')*

------
https://chatgpt.com/codex/tasks/task_e_686ce108d5588329af96f703a3e93e1f