### PR TITLE
Add getQuote request limit

### DIFF
--- a/convert_notifier.py
+++ b/convert_notifier.py
@@ -49,6 +49,11 @@ def _send(text: str) -> None:
         pass
 
 
+def send_telegram(text: str) -> None:
+    """Simple helper to send raw Telegram messages."""
+    _send(text)
+
+
 def notify_success(from_token: str, to_token: str, amount: float, to_amount: float, score: float, expected_profit: float) -> None:
     if _current_from_token and from_token != _current_from_token:
         flush_failures()


### PR DESCRIPTION
## Summary
- add QUOTE_REQUEST_LIMIT global and counter
- check quota before each getQuote call and exit when exceeded or when Binance API limit occurs
- send Telegram notification if Binance Convert limit reached
- expose simple `send_telegram` helper

## Testing
- `python -m py_compile convert_cycle.py convert_notifier.py`


------
https://chatgpt.com/codex/tasks/task_e_686ce60c7024832985de19f2ce8fd8ff