### PR TITLE
Implement persistent quote limit counter

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -8,6 +8,7 @@ import requests
 
 from config_dev3 import BINANCE_API_KEY, BINANCE_SECRET_KEY
 from utils_dev3 import get_current_timestamp
+from quote_counter import increment
 
 BASE_URL = "https://api.binance.com"
 
@@ -54,6 +55,7 @@ def get_available_to_tokens(from_token: str) -> List[str]:
 
 
 def get_quote(from_token: str, to_token: str, amount: float) -> Dict[str, Any]:
+    increment()
     url = f"{BASE_URL}/sapi/v1/convert/getQuote"
     params = _sign({"fromAsset": from_token, "toAsset": to_token, "fromAmount": amount})
     resp = _session.post(url, params=params, headers=_headers(), timeout=10)

--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -9,17 +9,16 @@ from convert_logger import (
 from convert_model import predict
 from convert_filters import filter_top_tokens
 from convert_notifier import send_telegram
+from quote_counter import get_count, QUOTE_LIMIT, seconds_until_reset
+import time
 
 
 # Allow executing quotes with low score for model training
 allow_learning_quotes = True
 
-QUOTE_REQUEST_LIMIT = 500  # безпечний денний ліміт для getQuote
-quote_request_count = 0
 
 
 def process_pair(from_token: str, to_tokens: List[str], amount: float, score_threshold: float):
-    global quote_request_count
     logger.info(f"[dev3] 🔍 Аналіз для {from_token} → {len(to_tokens)} токенів")
     top_results: List[Tuple[str, float, Dict]] = []
     quotes_map: Dict[str, Dict] = {}
@@ -28,11 +27,16 @@ def process_pair(from_token: str, to_tokens: List[str], amount: float, score_thr
     skipped_pairs: List[Tuple[str, float, str]] = []  # (token, score, reason)
 
     for to_token in to_tokens:
-        if quote_request_count >= QUOTE_REQUEST_LIMIT:
+        if get_count() >= QUOTE_LIMIT:
+            current = get_count()
             logger.warning(
-                "[dev3] 🛑 Досягнуто QUOTE_REQUEST_LIMIT (%s), цикл завершено.",
-                quote_request_count,
+                "[dev3] 🛑 Досягнуто QUOTE_LIMIT (%s), цикл завершено.",
+                current,
             )
+            send_telegram(
+                "[dev3] ❗ Досягнуто ліміту getQuote — цикл завершено."
+            )
+            time.sleep(seconds_until_reset())
             break
 
         quote = get_quote(from_token, to_token, amount)
@@ -45,7 +49,6 @@ def process_pair(from_token: str, to_tokens: List[str], amount: float, score_thr
             )
             break
 
-        quote_request_count += 1
         quotes_map[to_token] = quote
         # Save all quotes for training, even if not accepted later
         if quote and "ratio" in quote:

--- a/quote_counter.py
+++ b/quote_counter.py
@@ -1,0 +1,59 @@
+import json
+import os
+import time
+from datetime import datetime, timezone, timedelta
+
+QUOTE_COUNT_FILE = os.path.join("logs", "quote_count.json")
+QUOTE_LIMIT = 950
+
+
+def _load() -> dict:
+    if os.path.exists(QUOTE_COUNT_FILE):
+        with open(QUOTE_COUNT_FILE, "r", encoding="utf-8") as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+
+def _save(data: dict) -> None:
+    os.makedirs("logs", exist_ok=True)
+    with open(QUOTE_COUNT_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def get_count() -> int:
+    data = _load()
+    today = _today()
+    if data.get("date") != today:
+        data = {"date": today, "count": 0}
+        _save(data)
+        return 0
+    return int(data.get("count", 0))
+
+
+def increment() -> int:
+    today = _today()
+    data = _load()
+    if data.get("date") != today:
+        data = {"date": today, "count": 1}
+    else:
+        data["count"] = int(data.get("count", 0)) + 1
+    _save(data)
+    return data["count"]
+
+
+def seconds_until_reset() -> float:
+    now = datetime.now(timezone.utc)
+    tomorrow = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    return (tomorrow - now).total_seconds()
+
+
+def wait_until_reset() -> None:
+    time.sleep(seconds_until_reset())
+    _save({"date": _today(), "count": 0})


### PR DESCRIPTION
## Summary
- track usage of `get_quote` with a persistent counter in `logs/quote_count.json`
- enforce daily limit in `convert_cycle`
- increment counter inside `get_quote`

## Testing
- `python3 -m py_compile convert_api.py convert_cycle.py quote_counter.py`
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce987aac48329b30fbd84bb6cbdfb