### PR TITLE
Add quote limit guard to trading script

### DIFF
--- a/run_convert_trade.py
+++ b/run_convert_trade.py
@@ -6,6 +6,11 @@ from convert_api import get_balances, get_available_to_tokens
 from convert_cycle import process_pair
 from convert_logger import logger
 from config_dev3 import CONVERT_SCORE_THRESHOLD
+from quote_counter import can_request_quote
+
+if not can_request_quote():
+    print("⛔ Ліміт запитів до Convert API досягнуто. Пропускаємо цикл.")
+    exit(0)
 
 CACHE_FILES = [
     "signals.txt",


### PR DESCRIPTION
## Summary
- check API quote limit in `run_convert_trade` before starting trading cycle

## Testing
- `pytest -q`
- `python3 run_convert_trade.py | head` *(fails: ModuleNotFoundError: No module named 'config_dev3')*

------
https://chatgpt.com/codex/tasks/task_e_686d0bb72e3c8329b9cd54d159438617