### PR TITLE
Add debug prints for dataframe in training script

### DIFF
--- a/train_convert_model.py
+++ b/train_convert_model.py
@@ -37,6 +37,9 @@ def main() -> None:
 
     df = pd.DataFrame(dataset)
 
+    print("[DEBUG] df.columns:", df.columns.tolist())
+    print("[DEBUG] df head:\n", df.head())
+
     accepted = df[df["accepted"] == True]
     rejected = df[df["accepted"] == False]
 


### PR DESCRIPTION
## Summary
- log dataframe columns and first rows before filtering by `accepted`

## Testing
- `python -m py_compile train_convert_model.py`

------
https://chatgpt.com/codex/tasks/task_e_686fa6ed509083299ab704c92d389383