### PR TITLE
Fix convert_history reading orient

### DIFF
--- a/train_convert_model.py
+++ b/train_convert_model.py
@@ -24,7 +24,7 @@ log = logger.info
 
 
 def main():
-    df = pd.read_json("convert_history.json")
+    df = pd.read_json("convert_history.json", orient="records")
     log(f"[DEBUG] Колонки: {df.columns.tolist()}")
     log(f"[DEBUG] Перші рядки:\n{df.head()}")
 


### PR DESCRIPTION
## Summary
- ensure train_convert_model.py reads `convert_history.json` as records

## Testing
- `python -m py_compile train_convert_model.py`


------
https://chatgpt.com/codex/tasks/task_e_686fb3b84fbc8329bb19933a5e20b5bb