### PR TITLE
Fix bool conversion for convert history

### DIFF
--- a/train_convert_model.py
+++ b/train_convert_model.py
@@ -25,6 +25,7 @@ log = logger.info
 
 def main():
     df = pd.read_json("convert_history.json", orient="records")
+    df["accepted"] = df["accepted"].astype(bool)
     log(f"[DEBUG] Колонки: {df.columns.tolist()}")
     log(f"[DEBUG] Перші рядки:\n{df.head()}")
 


### PR DESCRIPTION
## Summary
- ensure `accepted` column is boolean right after reading history

## Testing
- `python3 train_convert_model.py` *(fails: File convert_history.json does not exist)*
- `pip install joblib`
- `pip install numpy pandas scikit-learn`
- `python3 train_convert_model.py` *(generates model_convert.joblib)*
- `pip install requests`
- `python3 daily_analysis.py --mode convert` *(fails: No module named 'config_dev3')*

------
https://chatgpt.com/codex/tasks/task_e_686fb71a9f3c83299125982b213bfca2