### PR TITLE
Fix accepted type conversion on load

### DIFF
--- a/train_convert_model.py
+++ b/train_convert_model.py
@@ -33,7 +33,6 @@ def main():
         log("❌ Колонка 'accepted' відсутня у convert_history.json. Навчання неможливе.")
         return
 
-    df["accepted"] = df["accepted"].astype(bool)
     accepted = df[df["accepted"]]
     rejected = df[~df["accepted"]]
 


### PR DESCRIPTION
## Summary
- ensure `accepted` column cast to boolean immediately after loading history
- remove duplicate conversion after column check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fbc5018d0832985e3b412d0b4c78c