### PR TITLE
Align convert model training features

### DIFF
--- a/train_convert_model.py
+++ b/train_convert_model.py
@@ -9,11 +9,22 @@ MODEL_PATH = "model_convert.joblib"
 HISTORY_PATH = "logs/convert_history.json"
 
 def extract_features(data):
-    feature_keys = ["expected_profit", "prob_up", "score", "volatility"]
-    df = pd.DataFrame([
-        {k: float(trade.get(k, 0)) for k in feature_keys}
-        for trade in data
-    ])
+    """Convert raw history records into a DataFrame of features."""
+
+    # `predict()` from :mod:`convert_model` expects five input features in the
+    # following order.  To ensure the model is trained on data with the same
+    # structure we include all of them here as well.
+    feature_keys = [
+        "expected_profit",
+        "prob_up",
+        "score",
+        "volatility",
+        "amount",
+    ]
+
+    df = pd.DataFrame(
+        [{k: float(trade.get(k, 0)) for k in feature_keys} for trade in data]
+    )
     return df
 
 def extract_labels(data):


### PR DESCRIPTION
## Summary
- ensure `train_convert_model.py` uses the same five features expected during inference
- document the list of features

## Testing
- `python3 train_convert_model.py` *(runs with empty history file)*

------
https://chatgpt.com/codex/tasks/task_e_6874a051b87c832981492e77f623404d