### PR TITLE
Allow fallback training trades and relax filters

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -105,7 +105,7 @@ async def main() -> None:
     await asyncio.to_thread(save_json, os.path.join("logs", "predictions.json"), predictions)
 
     sorted_tokens = sorted(predictions, key=lambda x: x["score"], reverse=True)
-    top_tokens = sorted_tokens[:5]
+    top_tokens = sorted_tokens[:10]
     if not top_tokens:
         logger.warning("[dev3] ❌ top_tokens.json порожній — відсутні релевантні прогнози")
     top_tokens_path = os.path.join(os.path.dirname(__file__), "top_tokens.json")


### PR DESCRIPTION
## Summary
- raise `TOP_N_PAIRS` from 5 to 10
- relax score and amount rules in `passes_filters`
- perform a fallback training conversion if no conversions succeed
- keep top ten pairs in `daily_analysis`

## Testing
- `python -m py_compile convert_filters.py convert_cycle.py daily_analysis.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68766fa1bbcc832996ae4d9399029b2a