### PR TITLE
Fix convert history logging

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -81,21 +81,6 @@ def try_convert(from_token: str, to_token: str, amount: float, score: float) -> 
     reason = resp.get("msg") if isinstance(resp, dict) else "Unknown error"
     log_conversion_error(from_token, to_token, reason)
     notify_failure(from_token, to_token, reason=reason)
-    save_convert_history(
-        {
-            "from": from_token,
-            "to": to_token,
-            "features": [
-                float(quote.get("ratio", 0)),
-                float(quote.get("inverseRatio", 0)),
-                float(amount),
-                _hash_token(from_token),
-                _hash_token(to_token),
-            ],
-            "profit": 0.0,
-            "accepted": False,
-        }
-    )
     return False
 
 
@@ -263,21 +248,6 @@ def process_top_pairs(pairs: List[Dict[str, Any]] | None = None) -> None:
             )
             log_conversion_error(from_token, to_token, reason)
             notify_failure(from_token, to_token, reason=reason)
-            save_convert_history(
-                {
-                    "from": from_token,
-                    "to": to_token,
-                    "features": [
-                        float(quote.get("ratio", 0)),
-                        float(quote.get("inverseRatio", 0)),
-                        float(amount),
-                        _hash_token(from_token),
-                        _hash_token(to_token),
-                    ],
-                    "profit": 0.0,
-                    "accepted": False,
-                }
-            )
 
     if not any_successful_conversion and scored_quotes:
         fallback = max(scored_quotes, key=lambda x: x["score"])

--- a/convert_logger.py
+++ b/convert_logger.py
@@ -7,6 +7,7 @@ LOG_FILE = os.path.join("logs", "convert_trade.log")
 DEBUG_LOG_FILE = os.path.join("logs", "convert_debug.log")
 ERROR_LOG_FILE = os.path.join("logs", "convert_errors.log")
 BALANCE_LOG_FILE = os.path.join("logs", "balance_guard.log")
+HISTORY_FILE = os.path.join("logs", "convert_history.json")
 
 
 os.makedirs("logs", exist_ok=True)
@@ -80,9 +81,9 @@ def log_quote(from_token: str, to_token: str, quote_data: dict) -> None:
 
 
 def log_convert_history(entry: dict):
-    """Append a single convert entry to logs/convert_history.json"""
+    """Append a single convert entry to HISTORY_FILE"""
     os.makedirs("logs", exist_ok=True)
-    path = "logs/convert_history.json"
+    path = HISTORY_FILE
 
     if os.path.exists(path):
         with open(path, "r") as f:


### PR DESCRIPTION
## Summary
- log conversion history only after Binance confirms success
- centralize history file path in `convert_logger`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687b2c48860c83298cbc2ad9f0957e8e