### PR TITLE
Fix json import for top token loader

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Any, Tuple, List, Dict
 import hashlib
+import json
 
 import numpy as np
 


### PR DESCRIPTION
## Summary
- include missing `json` import in `convert_model.py`

## Testing
- `python -m py_compile convert_model.py`

------
https://chatgpt.com/codex/tasks/task_e_687b388a5d688329b4e8133a4739c395