### PR TITLE
Improve training logging

### DIFF
--- a/train_convert_model.py
+++ b/train_convert_model.py
@@ -3,6 +3,14 @@ import os
 import sys
 from typing import Any, Dict, List
 from datetime import datetime, timezone
+import logging
+
+logging.basicConfig(
+    filename="logs/train_model.log",
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    encoding="utf-8",
+)
 
 import pandas as pd
 from convert_logger import logger
@@ -27,40 +35,38 @@ def load_convert_history(path: str = "convert_history.json") -> List[Dict[str, A
         return []
 
 def main():
-    history = load_convert_history(HISTORY_PATH)
-    if not history:
-        logger.warning("⛔️ Історія порожня або недоступна.")
-        return
+    try:
+        history = load_convert_history(HISTORY_PATH)
+        if not history:
+            logger.warning("⛔️ Історія порожня або недоступна.")
+            return
 
-    prepared = prepare_dataset(history)
-    if not prepared:
-        logger.error("❌ Немає даних після фільтрації prepare_dataset.")
-        return
+        prepared = prepare_dataset(history)
+        if not prepared:
+            logger.error("❌ Немає даних після фільтрації prepare_dataset.")
+            return
 
-    X = extract_features(prepared)
-    if X.shape[1] == 0 or X.size == 0:
-        logger.error(
-            "[dev3] ❌ Навчання зупинено: неможливо згенерувати ознаки — масив features порожній."
+        X = extract_features(prepared)
+        if X.shape[1] == 0 or X.size == 0:
+            logger.error(
+                "[dev3] ❌ Навчання зупинено: неможливо згенерувати ознаки — масив features порожній."
+            )
+            sys.exit(1)
+
+        y = extract_labels(prepared)
+
+        if len(y) == 0:
+            logger.warning("⚠️ Немає міток для навчання.")
+            return
+
+        model = train_model(X, y)
+        save_model(model, MODEL_PATH)
+
+        logging.info(
+            f"\u2705 \u041d\u0430\u0432\u0447\u0430\u043d\u043d\u044f \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043d\u043e. \u0420\u044f\u0434\u043a\u0456\u0432 \u0443 \u0434\u0430\u0442\u0430\u0441\u0435\u0442\u0456: {len(X)}"
         )
-        sys.exit(1)
-
-    y = extract_labels(prepared)
-
-    if len(y) == 0:
-        logger.warning("⚠️ Немає міток для навчання.")
-        return
-
-    model = train_model(X, y)
-    save_model(model, MODEL_PATH)
-
-    os.makedirs("logs", exist_ok=True)
-    with open(os.path.join("logs", "train_model.log"), "a", encoding="utf-8") as f:
-        f.write(
-            "[dev3] \u2705 \u041c\u043e\u0434\u0435\u043b\u044c \u043d\u0430\u0432\u0447\u0435\u043d\u0430\n"
-        )
-        f.write(f"\u041f\u0440\u0438\u043a\u043b\u0430\u0434\u0456\u0432: {len(y)}\n")
-        f.write(f"\u0424\u0430\u0439\u043b: {MODEL_PATH}\n")
-        f.write(f"\u0427\u0430\u0441: {datetime.now(timezone.utc).isoformat()}\n")
+    except Exception:
+        logging.exception("❌ Помилка під час навчання моделі")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- configure Python logging in `train_convert_model.py`
- replace manual file writes with `logging.info`
- wrap training logic in try/except and log exceptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f2f7cad288329a98dd0b17635c81b