### PR TITLE
Handle GPT failures in convert analysis

### DIFF
--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -1,0 +1,42 @@
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+async def ask_gpt(prompt: str, model: str = "gpt-4o") -> Optional[str]:
+    """Send ``prompt`` to OpenAI and return the response text.
+
+    Returns ``None`` if the request fails or the library is unavailable.
+    """
+    try:
+        from openai import AsyncOpenAI
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logger.warning("[dev3] ❌ openai import error: %s", exc)
+        return None
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        logger.warning("[dev3] ❌ OPENAI_API_KEY not set")
+        return None
+
+    client = AsyncOpenAI(api_key=api_key)
+
+    try:
+        response = await client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.3,
+        )
+    except Exception as exc:  # pragma: no cover - network
+        logger.warning("[dev3] ❌ GPT request failed: %s", exc)
+        return None
+
+    try:
+        content = response.choices[0].message.content
+    except Exception as exc:  # pragma: no cover - response
+        logger.warning("[dev3] ❌ GPT response parse error: %s", exc)
+        return None
+
+    return content.strip() if content else None


### PR DESCRIPTION
## Summary
- notify when GPT forecast text is missing
- fall back to score-based tokens if GPT fails
- send Telegram alert when GPT remains unresponsive
- provide `gpt_utils.ask_gpt` helper

## Testing
- `pytest -q`
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_68807302214483299877e00a50bfd588