### PR TITLE
Fix dev3 GPT API key import

### DIFF
--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -1,6 +1,7 @@
 import logging
-import os
 from typing import Optional
+
+from config_dev3 import OPENAI_API_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ async def ask_gpt(prompt: str, model: str = "gpt-4o") -> Optional[str]:
         logger.warning("[dev3] ❌ openai import error: %s", exc)
         return None
 
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key = OPENAI_API_KEY
     if not api_key:
         logger.warning("[dev3] ❌ OPENAI_API_KEY not set")
         return None


### PR DESCRIPTION
## Summary
- adjust `gpt_utils.py` to import `OPENAI_API_KEY` from `config_dev3`
- stop using `os.getenv` for the key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880786097748329a0f3e6d057b3d7b9