### PR TITLE
Limit Convert API usage

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from typing import List, Dict, Any
 
 from convert_api import (
-    get_quote,
+    get_quote_with_retry,
     accept_quote,
     get_balances,
     is_convertible_pair,
@@ -102,7 +102,7 @@ def try_convert(from_token: str, to_token: str, amount: float, score: float) -> 
         )
         return False
 
-    quote = get_quote(from_token, to_token, amount)
+    quote = get_quote_with_retry(from_token, to_token, amount)
     if not quote or quote.get("price") is None:
         logger.warning(
             f"⛔️ Пропуск {from_token} → {to_token}: quote.price is None після всіх спроб"
@@ -342,7 +342,7 @@ def process_top_pairs(pairs: List[Dict[str, Any]] | None = None) -> None:
                 logger.warning(f"[dev3] 🚫 Досягнуто ліміту {MAX_QUOTES_PER_CYCLE} quote-запитів у цьому циклі")
                 return
             quote_counter += 1
-            quote = get_quote(from_token, to_token, amount)
+            quote = get_quote_with_retry(from_token, to_token, amount)
             if not quote or quote.get("price") is None:
                 logger.warning(
                     f"⛔️ Пропуск {from_token} → {to_token}: quote.price is None після всіх спроб"

--- a/convert_filters.py
+++ b/convert_filters.py
@@ -4,7 +4,7 @@ import json
 from typing import Dict, Tuple, List, Any
 
 from convert_logger import logger
-from convert_api import get_symbol_price
+from binance_api import get_symbol_price
 
 # Allow slight negative scores and smaller toAmount for training trades
 MIN_SCORE = -0.0005


### PR DESCRIPTION
## Summary
- use Binance spot API in analytics
- add spot helpers in `binance_api`
- update filter utils to pull prices from Binance spot
- restrict Convert API calls to convert cycle with retry

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881cb0e6a9c832996d52c7552fd1c54