### PR TITLE
Improve fallback trade handling

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -29,9 +29,16 @@ def save_model(model, path=MODEL_PATH):
 
 def prepare_dataset(history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Filter raw history into a dataset used for training."""
-    return [
-        x for x in history if x.get("score", 0) > 0 and x.get("expected_profit", 0) > 0
-    ]
+    prepared: List[Dict[str, Any]] = []
+    for row in history:
+        if row.get("price") is None:
+            continue
+        if float(row.get("score", 0)) <= 0:
+            continue
+        item = dict(row)
+        item["executed"] = bool(row.get("accepted"))
+        prepared.append(item)
+    return prepared
 
 
 def extract_labels(data: List[Dict[str, Any]]) -> List[int]:


### PR DESCRIPTION
## Summary
- handle Binance precision when requesting convert quotes
- add per-token quote limits and better fallback trading
- log executed status in training dataset
- adjust Telegram notifier for fallback trades

## Testing
- `pytest -q`
- `python run_convert_trade.py` *(fails: missing config or network)*

------
https://chatgpt.com/codex/tasks/task_e_6881e064f9ac83298c13b9e16a5e35c6