### PR TITLE
Fix missing get_ratio import

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -5,7 +5,7 @@ import os
 from typing import Callable, Dict, List, Optional
 
 from convert_api import get_available_to_tokens, get_balances
-from binance_api import get_spot_price
+from binance_api import get_spot_price, get_ratio
 from convert_logger import logger
 from convert_notifier import send_telegram
 from gpt_utils import ask_gpt


### PR DESCRIPTION
## Summary
- import `get_ratio` from `binance_api` in `daily_analysis.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e43f842c8329b6a411de95ddd5f3