### PR TITLE
Fix IndexError on single-class models

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -146,7 +146,21 @@ def predict(
         features = features / norm
 
         if hasattr(model, "predict_proba"):
-            prob_up = float(model.predict_proba(features)[0][1])
+            probas = model.predict_proba(features)[0]
+            if len(probas) == 2:
+                prob_up = float(probas[1])
+            elif model.classes_[0] == 1:
+                prob_up = float(probas[0])
+            else:
+                prob_up = 0.0
+                logger.warning(
+                    "[dev3] \u26A0\uFE0F Model has only one class: %s — prediction may be biased",
+                    model.classes_,
+                )
+                logger.warning(
+                    "[dev3] \U0001f916 Model prediction fallback: prob_up=%.3f",
+                    prob_up,
+                )
         else:
             prob_up = float(model.predict(features)[0])
 

--- a/train_convert_model.py
+++ b/train_convert_model.py
@@ -64,6 +64,13 @@ def main():
             logger.warning("⚠️ Немає міток для навчання.")
             return
 
+        if pd.Series(y).nunique() < 2:
+            logger.error(
+                "[dev3] \u274c Cannot train model \u2014 only one class (%s) in label column",
+                pd.Series(y).unique(),
+            )
+            sys.exit(1)
+
         model = train_model(X, y)
         save_model(model, MODEL_PATH)
 


### PR DESCRIPTION
## Summary
- guard against single-class predictions in `convert_model`
- stop training if only one label in dataset

## Testing
- `pytest -q`
- `python3 train_convert_model.py` *(fails: no data)*
- `python3 daily_analysis.py --mode convert` *(fails: ModuleNotFoundError: config_dev3)*

------
https://chatgpt.com/codex/tasks/task_e_6882083b12e08329829a29ecb32fa07c