### PR TITLE
Fix executed flag in prepare_dataset

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -35,10 +35,17 @@ def prepare_dataset(history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         return []
 
     df = pd.DataFrame(history)
+
+    # Фільтруємо записи без expected_profit
     if "expected_profit" in df.columns:
         df = df[df["expected_profit"].notnull()]
 
-    df["executed"] = df.get("accepted", False).astype(bool)
+    # Визначаємо колонку executed
+    if "accepted" in df.columns:
+        df["executed"] = df["accepted"].fillna(False).astype(bool)
+    else:
+        df["executed"] = False
+
     return df.to_dict("records")
 
 


### PR DESCRIPTION
## Summary
- fix bug in `prepare_dataset` where `executed` column could be created from a single bool
- ensure missing `accepted` values default to `False`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688317d3c7788329a4c4f927961814be