### PR TITLE
Fix executed flag preservation

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -42,7 +42,9 @@ def prepare_dataset(history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         df = df[df["expected_profit"].notnull()]
 
     # Визначаємо колонку executed
-    if "accepted" in df.columns:
+    if "executed" in df.columns:
+        df["executed"] = df["executed"].fillna(False).astype(bool)
+    elif "accepted" in df.columns:
         df["executed"] = df["accepted"].fillna(False).astype(bool)
     else:
         df["executed"] = False  # Це створює колонку з одиним значенням (False), розшириться автоматично

--- a/test_prepare_dataset.py
+++ b/test_prepare_dataset.py
@@ -1,0 +1,22 @@
+import collections
+
+from convert_model import prepare_dataset
+
+
+def test_prepare_dataset_preserves_executed():
+    history = []
+    for i in range(20):
+        history.append({
+            "expected_profit": 0.1,
+            "accepted": True,
+            "executed": i != 0,
+            "ratio": 1.1,
+            "inverseRatio": 0.9,
+            "amount": 10.0,
+            "from_token": "AAA",
+            "to_token": "BBB",
+        })
+
+    prepared = prepare_dataset(history)
+    counts = collections.Counter(item["executed"] for item in prepared)
+    assert counts[True] == 19 and counts[False] == 1


### PR DESCRIPTION
## Summary
- preserve `executed` column from history when preparing dataset
- add regression test for `prepare_dataset`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688337fbcb148329ab2510a3cb309750