### PR TITLE
Fix hashing and invalid token handling

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -51,16 +51,16 @@ def prepare_dataset(history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
     dataset = df.to_dict("records")
 
-    # Remove rows with missing or invalid token names
-    dataset = [
-        row for row in dataset
-        if isinstance(row.get("from_token"), str)
-        and isinstance(row.get("to_token"), str)
-        and row.get("from_token") not in ("", "nan")
-        and row.get("to_token") not in ("", "nan")
-    ]
+    filtered = []
+    for row in dataset:
+        # Пропускати рядки з невалідними токенами
+        if not isinstance(row.get("from_token"), str) or not isinstance(row.get("to_token"), str):
+            continue
+        if row.get("from_token") in ("", "nan") or row.get("to_token") in ("", "nan"):
+            continue
+        filtered.append(row)
 
-    return dataset
+    return filtered
 
 def extract_labels(data: List[Dict[str, Any]]) -> List[int]:
     """Extract labels for model training."""
@@ -100,8 +100,9 @@ def is_fallback_model() -> bool:
 
 def _hash_token(token) -> float:
     """Convert token symbol to a normalized numeric hash."""
-    token_str = str(token) if not isinstance(token, str) else token
-    return float(int(hashlib.sha256(token_str.encode()).hexdigest(), 16) % 10**8) / 1e8
+    return float(
+        int(hashlib.sha256(str(token).encode()).hexdigest(), 16) % 10**8
+    ) / 1e8
 
 
 def extract_features(history: List[Dict[str, Any]]) -> np.ndarray:


### PR DESCRIPTION
## Summary
- handle None or float tokens when hashing
- skip invalid token types when preparing dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68833b98c62c8329809a234e1e068bfa