### PR TITLE
Fix token hashing crash

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -116,8 +116,8 @@ def _hash_token(token) -> float:
     Any unexpected value (e.g. ``None`` or ``NaN``) results in ``0.0`` so that
     calling code never fails.
     """
+    token_str = str(token)
     try:
-        token_str = str(token)
         return float(
             int(hashlib.sha256(token_str.encode()).hexdigest(), 16) % 10**8
         ) / 1e8


### PR DESCRIPTION
## Summary
- avoid AttributeError when hashing by always converting token to string

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68835c6686248329aa75571fa2c3f9c6