### PR TITLE
Fix dataset creation logic

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -35,7 +35,9 @@ def prepare_dataset(history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     if not history:
         return []
 
-    df = pd.DataFrame(history)
+    df = pd.DataFrame(
+        [item.get("value", {}) for item in history if isinstance(item, dict) and "value" in item]
+    )
 
     # Фільтруємо записи без expected_profit
     if "expected_profit" in df.columns:

--- a/test_prepare_dataset.py
+++ b/test_prepare_dataset.py
@@ -6,16 +6,20 @@ from convert_model import prepare_dataset
 def test_prepare_dataset_preserves_executed():
     history = []
     for i in range(20):
-        history.append({
-            "expected_profit": 0.1,
-            "accepted": True,
-            "executed": i != 0,
-            "ratio": 1.1,
-            "inverseRatio": 0.9,
-            "amount": 10.0,
-            "from_token": "AAA",
-            "to_token": "BBB",
-        })
+        history.append(
+            {
+                "value": {
+                    "expected_profit": 0.1,
+                    "accepted": True,
+                    "executed": i != 0,
+                    "ratio": 1.1,
+                    "inverseRatio": 0.9,
+                    "amount": 10.0,
+                    "from_token": "AAA",
+                    "to_token": "BBB",
+                }
+            }
+        )
 
     prepared = prepare_dataset(history)
     counts = collections.Counter(item["executed"] for item in prepared)


### PR DESCRIPTION
## Summary
- ensure `prepare_dataset` builds DataFrame from `value` fields only
- update `test_prepare_dataset` to provide `value`-wrapped input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688362929014832991085c22a960b700