### PR TITLE
Include tokens without price

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -191,19 +191,25 @@ def get_binance_balances() -> dict:
 
         symbol = asset + "USDT"
 
+        price = None
+        usdt_value = 0.0
         try:
-            price = float(get_symbol_price(symbol))
-            usdt_value = free * price
-            result[asset] = {
-                "free": free,
-                "price": price,
-                "notional": usdt_value,
-                "usdt_value": usdt_value,
-            }
-            total_usdt += usdt_value
-        except Exception as e:
+            raw_price = get_symbol_price(symbol)
+            if raw_price is not None:
+                price = float(raw_price)
+                usdt_value = free * price
+        except Exception as e:  # pragma: no cover - network/parse issues
             logger.warning(f"⚠️ Failed to fetch price for {symbol}: {e}")
-            continue
+
+        result[asset] = {
+            "free": free,
+            "price": price,
+            "notional": usdt_value if price is not None else None,
+            "usdt_value": usdt_value,
+        }
+
+        if usdt_value > 0.0:
+            total_usdt += usdt_value
 
     result["total"] = round(total_usdt, 4)
     return result


### PR DESCRIPTION
## Summary
- handle balance tokens that don't have a USDT price

## Testing
- `python3 -m py_compile binance_api.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68846cb5400883298ecc319d6d0d40da