### PR TITLE
Fix balance guard KeyError and log getQuote amounts

### DIFF
--- a/balance_guard.py
+++ b/balance_guard.py
@@ -30,7 +30,7 @@ def check_balance() -> None:
     diff = total - prev_total
 
     history = load_json(os.path.join("logs", "convert_history.json"))
-    last_trade = history[-1]["timestamp"] if history else "N/A"
+    last_trade = history[-1].get("timestamp", "N/A") if history else "N/A"
 
     if prev_total and diff < -prev_total * THRESHOLD:
         notify_failure("BALANCE", "USDT", "зменшення балансу >25%")

--- a/convert_api.py
+++ b/convert_api.py
@@ -207,6 +207,9 @@ def get_quote_with_retry(from_token: str, to_token: str, base_amount: float) -> 
         logger.info(
             f"[dev3] Retrying quote {from_token} → {to_token} з amount={amount}"
         )
+        logger.info(
+            f"[dev3] 🟡 getQuote: {from_token} → {to_token}, amount = {amount}"
+        )
         quote = get_quote(from_token, to_token, amount)
         if quote:
             if quote.get("msg") == "amount too low":


### PR DESCRIPTION
## Summary
- prevent `balance_guard` from crashing when trade history entries lack `timestamp`
- log each getQuote amount in `convert_api` before calling Binance

## Testing
- `python -m py_compile balance_guard.py convert_api.py`

------
https://chatgpt.com/codex/tasks/task_e_688506bfe0208329afc2df8d9a1927e7