### PR TITLE
Add attempt logging in get_quote

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -152,6 +152,9 @@ def get_quote(
     quote: Optional[Dict[str, Any]] = None
     for i in range(max_retries):
         logger.info(
+            f"[dev3] 🟡 Attempt {i + 1}: getQuote({from_token} → {to_token}, amount={amount})"
+        )
+        logger.info(
             f"🔁 Спроба {i+1}/{max_retries} отримати quote {from_token} → {to_token} з amount={amount:.10f}"
         )
         try:


### PR DESCRIPTION
## Summary
- improve logging inside `get_quote` to note each call with exact amount used

## Testing
- `python -m py_compile convert_api.py`


------
https://chatgpt.com/codex/tasks/task_e_688508919ad88329ad7e82b6b18e804f