### PR TITLE
Fix amount parsing and protect local limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+quote_limits.json

--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -7,6 +7,13 @@ from typing import List, Dict, Any
 
 from convert_logger import logger
 
+# Load local quote limits if available
+if os.path.exists("quote_limits.json"):
+    with open("quote_limits.json", "r", encoding="utf-8") as f:
+        quote_limits = json.load(f)
+else:
+    quote_limits = {}
+
 from convert_api import (
     get_quote_with_retry,
     accept_quote,
@@ -166,6 +173,13 @@ def try_convert(from_token: str, to_token: str, amount: float, score: float) -> 
         )
         log_quote_skipped(from_token, to_token, "invalid_quote")
         return False
+
+    amount_data = quote.get("amount", 0.0)
+    if isinstance(amount_data, dict):
+        amount = amount_data.get("from", 0.0)
+    else:
+        amount = amount_data
+    logger.info(f"[dev3] Quote amount: {amount}")
 
     if float(quote.get("toAmount", 0)) < min_notional(to_token):
         logger.info(

--- a/train_convert_model.py
+++ b/train_convert_model.py
@@ -61,6 +61,12 @@ def main():
             return
 
         prepared = prepare_dataset(history)
+        for row in prepared:
+            amount_data = row.get("amount", 0.0)
+            if isinstance(amount_data, dict):
+                row["amount"] = float(amount_data.get("from", 0.0))
+            else:
+                row["amount"] = float(amount_data)
         if not prepared:
             logger.error("❌ Немає даних після фільтрації prepare_dataset.")
             return


### PR DESCRIPTION
## Summary
- protect quote_limits.json locally and ignore in git
- normalize amount parsing in convert model
- adjust training script for amount field
- log quote amount and load local limits in convert cycle

## Testing
- `python -m py_compile convert_model.py train_convert_model.py convert_cycle.py`

------
https://chatgpt.com/codex/tasks/task_e_68851256436c83298f23df7bdd171900