### PR TITLE
Fix get_supported_pairs handling

### DIFF
--- a/convert_logger.py
+++ b/convert_logger.py
@@ -192,3 +192,8 @@ def log_conversion_error(from_token: str, to_token: str, error: str) -> None:
 def log_skipped_quotes() -> None:
     """Log that quote requests were skipped due to limit."""
     logger.warning("[dev3] \u23F8\ufe0f Достигнуто лiмiт запитiв get_quote за цикл")
+
+
+def log_error(message: str) -> None:
+    """Log an error message to the main logger."""
+    logger.error(message)


### PR DESCRIPTION
## Summary
- update `get_supported_pairs` to handle list responses from Binance
- expose `log_error` helper in `convert_logger`
- import `log_error` in `convert_api`

## Testing
- `python -m py_compile convert_api.py convert_logger.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885c958e2f883299c136b2063b01326