### PR TITLE
Fix convert_api get_quote payload

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -197,7 +197,11 @@ def get_quote(
     rounded_amount = float(Decimal(str(amount)).quantize(quant, rounding=ROUND_DOWN))
     amount = rounded_amount
 
-    params = _sign({"fromAsset": from_token, "toAsset": to_token, "fromAmount": amount})
+    payload = _sign({
+        "fromAsset": from_token,
+        "toAsset": to_token,
+        "fromAmount": str(amount)
+    })
 
     # Validate amount before requesting actual quote
     min_val = _validate_min_amount(from_token, to_token, amount)
@@ -213,7 +217,7 @@ def get_quote(
             f"🔁 Спроба {i+1}/{max_retries} отримати quote {from_token} → {to_token} з amount={amount:.10f}"
         )
         try:
-            resp = _session.post(url, data=params, headers=_headers(), timeout=10)
+            resp = _session.post(url, json=payload, headers=_headers(), timeout=10)
             data = resp.json()
         except Exception as exc:  # pragma: no cover - network
             logger.warning("[dev3] get_quote error %s → %s: %s", from_token, to_token, exc)


### PR DESCRIPTION
## Summary
- send data to Binance Convert API with `json=payload`
- send `fromAmount` as string

## Testing
- `python -m py_compile convert_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68872962446c832982faf4fbe51adad3