### PR TITLE
Fix type issues with score fields

### DIFF
--- a/convert_filters.py
+++ b/convert_filters.py
@@ -4,6 +4,7 @@ import json
 from typing import Dict, Tuple, List, Any
 
 from convert_logger import logger
+from convert_model import safe_float
 from binance_api import get_spot_price, get_ratio
 
 
@@ -29,9 +30,9 @@ def filter_top_tokens(
     filtered = [
         (token, data)
         for token, data in all_tokens.items()
-        if data.get("score", 0) >= score_threshold
+        if safe_float(data.get("score", 0)) >= score_threshold
     ]
-    filtered.sort(key=lambda x: x[1].get("score", 0), reverse=True)
+    filtered.sort(key=lambda x: safe_float(x[1].get("score", 0)), reverse=True)
 
     # Fallback logic: select tokens with highest score even if below threshold
     if not filtered:
@@ -39,7 +40,9 @@ def filter_top_tokens(
             "[dev3] ❕ Немає токенів з високим score. Використовуємо навчальні угоди."
         )
         sorted_tokens = sorted(
-            all_tokens.items(), key=lambda x: x[1].get("score", 0), reverse=True
+            all_tokens.items(),
+            key=lambda x: safe_float(x[1].get("score", 0)),
+            reverse=True,
         )
         return sorted_tokens[:fallback_n]
 

--- a/convert_model.py
+++ b/convert_model.py
@@ -15,6 +15,16 @@ _model = None
 _is_fallback = False
 
 
+def safe_float(value: Any) -> float:
+    """Return float value, handling dicts like {"value": number}."""
+    if isinstance(value, dict):
+        return float(value.get("value", 0.0))
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def train_model(X, y):
     from sklearn.ensemble import RandomForestClassifier
 

--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -9,7 +9,7 @@ from binance_api import get_spot_price, get_ratio
 from convert_logger import logger
 from convert_notifier import send_telegram, notify_fallback_model_warning
 from gpt_utils import ask_gpt
-from convert_model import predict, _load_model, is_fallback_model
+from convert_model import predict, _load_model, is_fallback_model, safe_float
 from utils_dev3 import save_json
 
 _balance_cache: Dict[str, float] | None = None
@@ -173,7 +173,7 @@ async def convert_mode() -> None:
 
     top_tokens_by_score: List[Dict[str, float]] = []
     for items in grouped.values():
-        items.sort(key=lambda x: x["score"], reverse=True)
+        items.sort(key=lambda x: safe_float(x.get("score", 0)), reverse=True)
         top_tokens_by_score.extend(items[:10])
 
     # By default use score-based ranking


### PR DESCRIPTION
## Summary
- add `safe_float` helper in `convert_model`
- use `safe_float` to parse score values in token filtering and processing

## Testing
- `python -m py_compile convert_model.py convert_cycle.py convert_filters.py daily_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_688762a3b3ec83299546101d480fdc13