### PR TITLE
Fix convert cycle with safe float and fallback

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -396,6 +396,17 @@ def get_min_convert_amount(from_token: str, to_token: str) -> float:
     return float(min_val) if min_val is not None else 0.0
 
 
+def get_max_convert_amount(from_token: str, to_token: str) -> float:
+    """Return maximal allowed amount for conversion based on cached limits."""
+    limits = load_quote_limits()
+    key_underscore = f"{from_token}_{to_token}"
+    key_arrow = sanitize_token_pair(from_token, to_token)
+    info = limits.get(key_underscore) or limits.get(key_arrow)
+    if info:
+        return float(info.get("max_amount") or info.get("max") or float("inf"))
+    return float("inf")
+
+
 def get_all_supported_convert_pairs() -> Set[str]:
     """Return set of all supported convert pairs."""
     global _supported_pairs_cache

--- a/convert_filters.py
+++ b/convert_filters.py
@@ -4,8 +4,17 @@ import json
 from typing import Dict, Tuple, List, Any
 
 from convert_logger import logger
-from convert_model import safe_float
 from binance_api import get_spot_price, get_ratio
+
+
+def safe_float(value: Any) -> float:
+    """Return float value, handling dicts like {"value": number}."""
+    if isinstance(value, dict):
+        return float(value.get("value", 0.0))
+    try:
+        return float(value)
+    except Exception:
+        return 0.0
 
 
 def get_ratio_from_spot(from_token: str, to_token: str) -> float:


### PR DESCRIPTION
## Summary
- fix numeric handling by adding `safe_float` helpers
- ensure fallback conversion always executes and respects API limits
- add `get_max_convert_amount` utility
- skip invalid quotes with missing price or 401 code

## Testing
- `python -m py_compile convert_filters.py convert_cycle.py convert_api.py convert_model.py run_convert_trade.py`

------
https://chatgpt.com/codex/tasks/task_e_688763fd83d8832996aba40f04f920da