### PR TITLE
Fix metric comparisons in convert cycle

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -237,26 +237,27 @@ def process_top_pairs(pairs: List[Dict[str, Any]] | None = None) -> None:
 
         from_token = item.get("from_token")
         to_token = item.get("to_token")
-        raw_score = item.get("score", 0.0)
-        score = (
-            raw_score.get("predicted", 0.0)
-            if isinstance(raw_score, dict)
-            else float(raw_score)
+        score = item.get("score", 0)
+        if isinstance(score, dict):
+            score = score.get("value", score.get("predicted", 0))
+
+        expected_profit = item.get("expected_profit", 0)
+        if isinstance(expected_profit, dict):
+            expected_profit = expected_profit.get(
+                "value", expected_profit.get("predicted", 0)
+            )
+
+        prob_up = item.get("prob_up", 0)
+        if isinstance(prob_up, dict):
+            prob_up = prob_up.get("value", prob_up.get("predicted", 0))
+
+        logger.debug(
+            f"[dev3] 🧪 Обробка: score={score}, expected_profit={expected_profit}, prob_up={prob_up}"
         )
 
-        raw_expected_profit = item.get("expected_profit", 0.0)
-        expected_profit = (
-            raw_expected_profit.get("predicted", 0.0)
-            if isinstance(raw_expected_profit, dict)
-            else float(raw_expected_profit)
-        )
-
-        raw_prob_up = item.get("prob_up", 0.0)
-        prob_up = (
-            raw_prob_up.get("predicted", 0.0)
-            if isinstance(raw_prob_up, dict)
-            else float(raw_prob_up)
-        )
+        score = safe_float(score)
+        expected_profit = safe_float(expected_profit)
+        prob_up = safe_float(prob_up)
         amount = balances.get(from_token, 0)
         from convert_api import get_max_convert_amount
         max_allowed = get_max_convert_amount(from_token, to_token)


### PR DESCRIPTION
## Summary
- guard metric comparisons against nested dict values in `convert_cycle.py`
- add debug logging for normalized metrics

## Testing
- `python -m py_compile convert_cycle.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885568c0f483298e7e437fff9b2a78