### PR TITLE
Add GPT forecast diagnostics

### DIFF
--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -1,12 +1,13 @@
+import json
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from config_dev3 import OPENAI_API_KEY
 
 logger = logging.getLogger(__name__)
 
 
-async def ask_gpt(prompt: str, model: str = "gpt-4o") -> Optional[str]:
+async def ask_gpt(prompt: Any, mode: str = "", model: str = "gpt-4o") -> Optional[str]:
     """Send ``prompt`` to OpenAI and return the response text.
 
     Returns ``None`` if the request fails or the library is unavailable.
@@ -21,6 +22,9 @@ async def ask_gpt(prompt: str, model: str = "gpt-4o") -> Optional[str]:
     if not api_key:
         logger.warning("[dev3] ❌ OPENAI_API_KEY not set")
         return None
+
+    if not isinstance(prompt, str):
+        prompt = json.dumps(prompt, ensure_ascii=False)
 
     client = AsyncOpenAI(api_key=api_key)
 


### PR DESCRIPTION
## Summary
- log diagnostic when GPT forecast is missing
- ensure `.get()` uses an empty dict default
- accept any prompt type in `ask_gpt`

## Testing
- `python3 -m py_compile daily_analysis.py gpt_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688867bdcbf0832980ae81c9c6c3efbe