### PR TITLE
Fix forecast_map string crash

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -198,6 +198,13 @@ async def convert_mode() -> None:
     # 🧪 Timely logging of GPT forecast
     forecast_map = await ask_gpt(top_tokens, mode="convert")
 
+    if isinstance(forecast_map, str):
+        try:
+            forecast_map = json.loads(forecast_map)
+        except json.JSONDecodeError:
+            logger.warning("\u274c GPT forecast is not valid JSON")
+            forecast_map = {}
+
     if not forecast_map:
         print("❌ GPT forecast is empty or None — forecast_map:", forecast_map)
         os.makedirs("logs", exist_ok=True)


### PR DESCRIPTION
## Summary
- handle JSON string responses from GPT in `daily_analysis.py`

## Testing
- `python3 -m py_compile daily_analysis.py`
- `python3 daily_analysis.py --mode convert` *(fails: ModuleNotFoundError: No module named 'config_dev3')*

------
https://chatgpt.com/codex/tasks/task_e_68886b4019a083298bd406b5f8111953