### PR TITLE
Fix GPT forecast mapping

### DIFF
--- a/daily_analysis.py
+++ b/daily_analysis.py
@@ -217,7 +217,11 @@ async def convert_mode() -> None:
             json.dump(forecast_map, f, indent=2)
 
     for token in top_tokens:
-        pair_key = sanitize_token_pair(token.get("from_token"), token.get("to_token"))
+        token_from = token.get("from") or token.get("from_token")
+        token_to = token.get("to") or token.get("to_token")
+        if not token_from or not token_to:
+            continue
+        pair_key = f"{token_from}->{token_to}"
         token["gpt"] = forecast_map.get(pair_key, {})
 
     prompt: str = json.dumps({"predictions": predictions}, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- correct key generation when mapping GPT forecasts in `convert_mode`

## Testing
- `python3 -m py_compile daily_analysis.py`
- `python3 daily_analysis.py --mode convert` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_6888717426808329bae603bab9cdc10a