### PR TITLE
Fix GPT score lookup in convert_cycle

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -141,7 +141,9 @@ def fallback_convert(pairs: List[Dict[str, Any]], balances: Dict[str, float]) ->
         logger.warning("🔸 Причина: не знайдено жодного валідного `to_token` для fallback (score недостатній або немає прогнозу)")
         return False
 
-    best_pair = max(valid_to_tokens, key=lambda x: safe_float(x.get("score", 0)))
+    best_pair = max(
+        valid_to_tokens, key=lambda x: safe_float(x.get("gpt", {}).get("score", 0))
+    )
     selected_to_token = best_pair.get("to_token")
     amount = balances.get(fallback_token, 0.0)
     from convert_api import get_max_convert_amount
@@ -236,7 +238,9 @@ def process_top_pairs(pairs: List[Dict[str, Any]] | None = None) -> None:
         if safe_float(p.get("gpt", {}).get("score", 0))
         > GPT_SCORE_THRESHOLD
     ]
-    pairs.sort(key=lambda x: safe_float(x.get("score", 0)), reverse=True)
+    pairs.sort(
+        key=lambda x: safe_float(x.get("gpt", {}).get("score", 0)), reverse=True
+    )
     quote_count = 0
     any_successful_conversion = False
     successful_count = 0
@@ -379,7 +383,9 @@ def process_top_pairs(pairs: List[Dict[str, Any]] | None = None) -> None:
         return
 
     if not any_successful_conversion and scored_quotes:
-        fallback = max(scored_quotes, key=lambda x: safe_float(x.get("score", 0)))
+        fallback = max(
+            scored_quotes, key=lambda x: safe_float(x.get("gpt", {}).get("score", 0))
+        )
         log_reason = fallback.get("skip_reason", "no reason")
         logger.info(
             f"[dev3] ⚠️ Жодна пара не пройшла фільтри. Виконуємо fallback-конверсію: {fallback['from_token']} → {fallback['to_token']} (score={fallback['score']:.2f}, причина skip: {log_reason})"


### PR DESCRIPTION
## Summary
- fix lambda expressions to look at `gpt.score` instead of direct `score`

## Testing
- `python -m py_compile convert_cycle.py`


------
https://chatgpt.com/codex/tasks/task_e_68890d40eda083298886fc6625b11675