### PR TITLE
Fix fallback gpt score lookup

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -156,7 +156,7 @@ def fallback_convert(pairs: List[Dict[str, Any]], balances: Dict[str, float]) ->
         fallback_token,
         selected_to_token,
         amount,
-        safe_float(best_pair.get("score", 0)),
+        safe_float(best_pair.get("gpt", {}).get("score", 0)),
     )
 
 


### PR DESCRIPTION
## Summary
- use `safe_float(best_pair.get("gpt", {}).get("score", 0))` when passing score to `try_convert`
- avoid errors when `gpt` key contains nested objects

## Testing
- `python -m py_compile convert_cycle.py`


------
https://chatgpt.com/codex/tasks/task_e_68890fff3cac8329aa4baf0e91bf343d