### PR TITLE
Fix GPT score comparisons with shared safe_float

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -19,16 +19,7 @@ from convert_logger import (
 )
 from quote_counter import should_throttle, reset_cycle
 from convert_model import _hash_token
-
-
-def safe_float(val: Any) -> float:
-    """Return ``float`` value, handling nested ``{"value": x}`` dicts."""
-    if isinstance(val, dict):
-        val = val.get("value", 0.0)
-    try:
-        return float(val)
-    except (TypeError, ValueError):
-        return 0.0
+from utils_dev3 import safe_float
 
 
 def gpt_score(data: Dict[str, Any]) -> float:

--- a/convert_filters.py
+++ b/convert_filters.py
@@ -5,16 +5,7 @@ from typing import Dict, Tuple, List, Any
 
 from convert_logger import logger
 from binance_api import get_spot_price, get_ratio
-
-
-def safe_float(val: Any) -> float:
-    """Return ``float`` value, handling nested ``{"value": x}`` dicts."""
-    if isinstance(val, dict):
-        val = val.get("value", 0.0)
-    try:
-        return float(val)
-    except (TypeError, ValueError):
-        return 0.0
+from utils_dev3 import safe_float
 
 
 def get_ratio_from_spot(from_token: str, to_token: str) -> float:

--- a/convert_model.py
+++ b/convert_model.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import joblib
 import pandas as pd
+from utils_dev3 import safe_float
 
 MODEL_PATH = "model_convert.joblib"
 logger = logging.getLogger(__name__)
@@ -15,14 +16,6 @@ _model = None
 _is_fallback = False
 
 
-def safe_float(value: Any) -> float:
-    """Return float value, handling dicts like {"value": number}."""
-    if isinstance(value, dict):
-        return float(value.get("value", 0.0))
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return 0.0
 
 
 def train_model(X, y):

--- a/utils_dev3.py
+++ b/utils_dev3.py
@@ -2,6 +2,20 @@ import json
 import os
 import time
 from decimal import Decimal
+from typing import Any
+
+
+def safe_float(val: Any) -> float:
+    """Return float value, handling nested dicts like {"value": x}."""
+    if isinstance(val, dict):
+        if "value" in val:
+            val = val.get("value")
+        elif "predicted" in val:
+            val = val.get("predicted")
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def normalize_symbol(symbol: str) -> str:


### PR DESCRIPTION
## Summary
- add `safe_float` helper to `utils_dev3`
- import and reuse `safe_float` across convert modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68892129723483298fae07a61b8ad4d8