### PR TITLE
Fix gpt score comparison

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -169,9 +169,11 @@ def _load_top_pairs() -> List[Dict[str, Any]]:
     top_quotes: List[tuple[float, Dict[str, Any]]] = []
     for item in data:
         if isinstance(item, dict):
-            score_val = item.get("score", 0)
+            score_val = item.get("score")
+            if score_val is None:
+                score_val = item.get("gpt", {}).get("score", 0)
             if isinstance(score_val, dict):
-                score_val = score_val.get("predicted", 0)
+                score_val = score_val.get("predicted", score_val.get("value", 0))
             score = safe_float(score_val)
             top_quotes.append((score, item))
         elif isinstance(item, (list, tuple)) and len(item) >= 2:

--- a/convert_filters.py
+++ b/convert_filters.py
@@ -30,9 +30,13 @@ def filter_top_tokens(
     filtered = [
         (token, data)
         for token, data in all_tokens.items()
-        if safe_float(data.get("score", 0)) >= score_threshold
+        if safe_float(data.get("score", data.get("gpt", {}).get("score", 0)))
+        >= score_threshold
     ]
-    filtered.sort(key=lambda x: safe_float(x[1].get("score", 0)), reverse=True)
+    filtered.sort(
+        key=lambda x: safe_float(x[1].get("score", x[1].get("gpt", {}).get("score", 0))),
+        reverse=True,
+    )
 
     # Fallback logic: select tokens with highest score even if below threshold
     if not filtered:
@@ -41,7 +45,9 @@ def filter_top_tokens(
         )
         sorted_tokens = sorted(
             all_tokens.items(),
-            key=lambda x: safe_float(x[1].get("score", 0)),
+            key=lambda x: safe_float(
+                x[1].get("score", x[1].get("gpt", {}).get("score", 0))
+            ),
             reverse=True,
         )
         return sorted_tokens[:fallback_n]

--- a/convert_model.py
+++ b/convert_model.py
@@ -99,12 +99,12 @@ def extract_features(history: List[Dict[str, Any]]) -> np.ndarray:
         ratio_value = row.get("ratio")
         if ratio_value is None:
             logger.warning("[dev3] ratio is None in history row: %s", row)
-        ratio = float(ratio_value or 0.0)
+        ratio = safe_float(ratio_value)
 
         inverse_ratio_value = row.get("inverseRatio")
         if inverse_ratio_value is None:
             logger.warning("[dev3] inverseRatio is None in history row: %s", row)
-        inverse_ratio = float(inverse_ratio_value or 0.0)
+        inverse_ratio = safe_float(inverse_ratio_value)
 
         expected_profit_val = row.get("expected_profit")
         if expected_profit_val is None:
@@ -118,7 +118,7 @@ def extract_features(history: List[Dict[str, Any]]) -> np.ndarray:
         if score_val is None:
             logger.warning("[dev3] score is None in history row: %s", row)
 
-        amount = float(row.get("amount") or 0.0)
+        amount = safe_float(row.get("amount"))
         from_hash = _hash_token(row.get("from_token", ""))
         to_hash = _hash_token(row.get("to_token", ""))
         features_list.append([ratio, inverse_ratio, amount, from_hash, to_hash])
@@ -152,9 +152,9 @@ def predict(
         return 0.0, 0.0, 0.0
 
     try:
-        ratio = float(quote_data.get("ratio", 0.0))
-        inverse_ratio = float(quote_data.get("inverseRatio", 0.0))
-        amount = float(quote_data.get("amount", {}).get("from", 0.0))
+        ratio = safe_float(quote_data.get("ratio", 0.0))
+        inverse_ratio = safe_float(quote_data.get("inverseRatio", 0.0))
+        amount = safe_float(quote_data.get("amount", {}).get("from", 0.0))
 
         features = np.array(
             [


### PR DESCRIPTION
## Summary
- normalize score loading from top_tokens.json
- use GPT score fallback in convert_filters
- use `safe_float` when parsing model training data

## Testing
- `python -m py_compile convert_cycle.py convert_filters.py convert_model.py utils_dev3.py`

------
https://chatgpt.com/codex/tasks/task_e_688923c2e8e08329868cf3fa300a96ef