### PR TITLE
Fix None token handling in price helpers

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -46,6 +46,9 @@ def get_valid_symbols() -> set[str]:
 
 
 def get_historical_prices(symbol: str, interval: str = "5m", limit: int = 100):
+    if not symbol:
+        logger.warning("[dev3] ❌ Невірний токен: token=None під час symbol.upper()")
+        return []
     symbol = symbol.upper()
 
     if not symbol.endswith("USDT"):
@@ -99,6 +102,9 @@ def get_last_prices(symbol: str, limit: int = 100):
 
 def get_spot_price(token: str) -> Optional[float]:
     """Return current spot price of ``token`` in USDT with 60s cache."""
+    if not token:
+        logger.warning("[dev3] ❌ Невірний токен: token=None під час symbol.upper()")
+        return None
     token = token.upper()
     now = time.time()
     cached = _price_cache.get(token)
@@ -122,6 +128,9 @@ def get_spot_price(token: str) -> Optional[float]:
 def get_symbol_price(symbol: str) -> Optional[float]:
     """Return current price for ``symbol`` with unified USDT suffix."""
     # 🔧 Уніфікація: прибираємо зайве "USDT" у кінці, якщо є
+    if not symbol:
+        logger.warning("[dev3] ❌ Невірний токен: token=None під час symbol.upper()")
+        return None
     symbol = symbol.upper()
     if symbol.endswith("USDT") and not symbol.endswith("USDTUSDT"):
         symbol = symbol[:-4]
@@ -146,6 +155,9 @@ def get_24h_ticker_data(symbol: str) -> Dict[str, Any]:
     """Return 24h ticker data for the symbol."""
     url = f"{BASE_URL}/api/v3/ticker/24hr"
     try:
+        if not symbol:
+            logger.warning("[dev3] ❌ Невірний токен: token=None під час symbol.upper()")
+            return {}
         resp = requests.get(url, params={"symbol": symbol.upper()}, timeout=10)
         return resp.json()
     except Exception as exc:  # pragma: no cover - diagnostics only
@@ -155,6 +167,9 @@ def get_24h_ticker_data(symbol: str) -> Dict[str, Any]:
 
 def check_symbol_exists(from_token: str, to_token: str) -> bool:
     """Return True if ``to_token`` has a USDT pair on Binance."""
+    if not to_token:
+        logger.warning("[dev3] ❌ Невірний токен: token=None під час symbol.upper()")
+        return False
     symbol = f"{to_token}USDT".upper()
     valid_pairs = VALID_PAIRS or get_valid_symbols()
     return symbol in valid_pairs
@@ -162,6 +177,12 @@ def check_symbol_exists(from_token: str, to_token: str) -> bool:
 
 def get_ratio(base: str, quote: str) -> float:
     """Return ``quote/base`` price ratio using spot prices."""
+
+    if not base or not quote:
+        logger.warning(
+            "[dev3] ❌ Невірний токен: token=None під час symbol.upper()"
+        )
+        return 0.0
 
     base = base.upper()
     quote = quote.upper()
@@ -234,6 +255,9 @@ _lot_step_cache: dict[str, dict] = {}
 
 def get_lot_step(asset: str) -> dict:
     """Return LOT_SIZE filter for ``asset`` pair with USDT."""
+    if not asset:
+        logger.warning("[dev3] ❌ Невірний токен: token=None під час symbol.upper()")
+        return {"stepSize": "1"}
     asset = asset.upper()
     if asset in _lot_step_cache:
         return _lot_step_cache[asset]

--- a/convert_api.py
+++ b/convert_api.py
@@ -47,6 +47,9 @@ _min_amount_cache: Dict[tuple[str, str], float] = {}
 
 def sanitize_token_pair(from_token: str, to_token: str) -> str:
     """Return standardized key for quote limits."""
+    if not from_token or not to_token:
+        logger.warning("[dev3] ❌ Невірний токен: token=None під час symbol.upper()")
+        return ""
     return f"{from_token.upper()}→{to_token.upper()}"
 
 

--- a/convert_filters.py
+++ b/convert_filters.py
@@ -72,14 +72,26 @@ def passes_filters(score: float, quote: Dict[str, Any], balance: float) -> Tuple
     if to_amount <= from_amount:
         return False, "no_profit"
 
+    from_token = quote.get("fromAsset")
     to_token = quote.get("toAsset")
+    if not from_token or not to_token:
+        logger.warning(
+            "[dev3] ❌ Один із токенів None: from_token=%s, to_token=%s",
+            from_token,
+            to_token,
+        )
+        return False, "invalid_tokens"
+
+    from_symbol = from_token.upper()
+    to_symbol = to_token.upper()
+
     try:
-        to_price = get_spot_price(to_token)
+        to_price = get_spot_price(to_symbol)
         to_usdt_value = to_amount * to_price
     except Exception as e:
         return False, f"price_lookup_failed: {e}"
 
-    spot_ratio = get_ratio(quote.get("fromAsset"), to_token)
+    spot_ratio = get_ratio(from_symbol, to_symbol)
     if spot_ratio <= 0:
         return False, "spot_ratio_failed"
     if spot_ratio <= 1.0:

--- a/utils_dev3.py
+++ b/utils_dev3.py
@@ -19,6 +19,8 @@ def safe_float(val: Any) -> float:
 
 
 def normalize_symbol(symbol: str) -> str:
+    if not symbol:
+        return ""
     return symbol.upper().replace("USDT", "")
 
 


### PR DESCRIPTION
## Summary
- avoid `.upper()` on `None` in quote filtering and API helpers
- guard token utilities against missing symbols

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b48a1f9ec8329833e273ea11ff62d