### PR TITLE
Use full quote object when accepting a quote

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -83,7 +83,7 @@ def try_convert(from_token: str, to_token: str, amount: float, score: float) -> 
         return False
 
     quote_id = quote.get("quoteId")
-    resp = accept_quote(quote_id) if quote_id else None
+    resp = accept_quote(quote) if quote else None
     if resp and resp.get("success") is True:
         profit = safe_float(resp.get("toAmount", 0)) - safe_float(resp.get("fromAmount", 0))
         log_conversion_success(from_token, to_token, profit)


### PR DESCRIPTION
## Summary
- ensure accept_quote receives entire quote dictionary instead of just quoteId

## Testing
- `python -m py_compile convert_cycle.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688daea30edc8329936d316eb5d93648