### PR TITLE
Fix accept_quote token handling and logging

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -13,8 +13,6 @@ from convert_logger import (
     save_convert_history,
     log_prediction,
     log_quote_skipped,
-    log_conversion_success,
-    log_conversion_error,
     log_skipped_quotes,
     log_error,
 )
@@ -82,11 +80,9 @@ def try_convert(from_token: str, to_token: str, amount: float, score: float) -> 
         )
         return False
 
-    quote_id = quote.get("quoteId")
-    resp = accept_quote(quote, from_token, to_token) if quote else None
+    resp = accept_quote(quote, from_token, to_token)
     if resp and resp.get("success") is True:
         profit = safe_float(resp.get("toAmount", 0)) - safe_float(resp.get("fromAmount", 0))
-        log_conversion_success(from_token, to_token, profit)
         notify_success(
             from_token,
             to_token,
@@ -114,7 +110,6 @@ def try_convert(from_token: str, to_token: str, amount: float, score: float) -> 
         return True
 
     reason = resp.get("msg") if isinstance(resp, dict) else "Unknown error"
-    log_conversion_error(from_token, to_token, reason)
     notify_failure(from_token, to_token, reason=reason)
     save_convert_history(
         {


### PR DESCRIPTION
## Summary
- Pass from/to tokens explicitly to `accept_quote` and compute profit for logging
- Remove redundant conversion logging in `try_convert` and update call signature

## Testing
- `python -m py_compile convert_api.py convert_cycle.py`
- `rg "Один із токенів None" logs/convert_trade.log || echo 'no matches'`


------
https://chatgpt.com/codex/tasks/task_e_688db48731188329b6e3b0100e296853