### PR TITLE
Handle missing tokens in accept_quote and safe history load

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -260,6 +260,18 @@ def accept_quote(
     quote: Dict[str, Any], from_token: str, to_token: str
 ) -> Optional[Dict[str, Any]]:
     """Accept a quote if it is still valid."""
+    if not from_token or not to_token:
+        convert_logger.logger.warning(
+            "[dev3] ❌ Один із токенів None у accept_quote: from_token=%s, to_token=%s",
+            from_token,
+            to_token,
+        )
+        convert_logger.log_quote_skipped(
+            from_token or "None",
+            to_token or "None",
+            reason="⛔️ Пропущено: invalid_tokens",
+        )
+        return None
     created_at = quote.get("created_at")
     if created_at and (time.time() - created_at > 9.5):  # TTL Binance ~10s
         convert_logger.log_quote_skipped(

--- a/convert_logger.py
+++ b/convert_logger.py
@@ -103,30 +103,24 @@ def log_quote(from_token: str, to_token: str, quote_data: dict) -> None:
 
 
 def log_convert_history(entry: dict):
-    """Append a single convert entry to HISTORY_FILE"""
-    ensure_dir_exists("logs")
-    FILE_PATH = os.path.join("logs", "convert_history.json")
-    path = FILE_PATH
+    """Append a single convert entry to HISTORY_FILE."""
+    save_convert_history(entry)
 
-    if os.path.exists(path):
-        with open(path, "r") as f:
-            try:
-                history = json.load(f)
-            except json.JSONDecodeError:
-                history = []
-    else:
+
+def save_convert_history(entry: dict) -> None:
+    """Persist convert history entry safely handling missing file."""
+    ensure_dir_exists("logs")
+    try:
+        with open(HISTORY_FILE, "r") as f:
+            history = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
         history = []
 
     entry["timestamp"] = datetime.utcnow().isoformat()
     history.append(entry)
 
-    with open(path, "w") as f:
+    with open(HISTORY_FILE, "w") as f:
         json.dump(history, f, indent=2)
-
-
-def save_convert_history(entry: dict) -> None:
-    """Alias for log_convert_history for backward compatibility."""
-    log_convert_history(entry)
 
 
 def log_conversion_result(quote: dict, accepted: bool) -> None:


### PR DESCRIPTION
## Summary
- Validate `from_token` and `to_token` in `accept_quote`, logging and skipping when absent
- Safely load `convert_history.json` with fallback for missing file or JSON errors

## Testing
- `python -m py_compile convert_api.py convert_logger.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dbb0869548329aff8cbe66225f65d