### PR TITLE
Handle None from accept_quote and enrich quote data

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -192,13 +192,15 @@ def get_quote(from_asset: str, to_asset: str, amount: float) -> Optional[Dict[st
         response = requests.post(full_url, headers=headers)
         data = response.json()
 
-        if "ratio" in data and "toAmount" in data:
+        if "ratio" in data and "toAmount" in data and "quoteId" in data:
             return {
+                "quoteId": data["quoteId"],
                 "ratio": float(data["ratio"]),
-                "inverseRatio": float(data.get("inverseRatio", 0)),
+                "inverseRatio": float(data["inverseRatio"]),
                 "fromAmount": float(data["fromAmount"]),
                 "toAmount": float(data["toAmount"]),
-                "validUntil": data.get("validTimestamp"),
+                "validUntil": int(data["validUntil"]),
+                "created_at": time.time(),
             }
         else:
             convert_logger.warning(

--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -81,7 +81,10 @@ def try_convert(from_token: str, to_token: str, amount: float, score: float) -> 
         return False
 
     resp = accept_quote(quote, from_token, to_token)
-    if resp and resp.get("success") is True:
+    if resp is None:
+        notify_failure(from_token, to_token, reason="accept_quote returned None")
+        return False
+    if resp.get("status") == "success":
         profit = safe_float(resp.get("toAmount", 0)) - safe_float(resp.get("fromAmount", 0))
         notify_success(
             from_token,


### PR DESCRIPTION
## Summary
- include quoteId and timestamp in convert API quote responses
- log and stop when accept_quote returns None before processing

## Testing
- `python -m py_compile convert_api.py convert_cycle.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dcf2e4ba88329b7db01e311254ebd