### PR TITLE
Ensure get_quote returns fromToken and toToken

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -205,7 +205,7 @@ def get_quote(from_asset: str, to_asset: str, amount: float) -> Optional[Dict[st
                 log_quote_skipped(from_asset, to_asset, reason="invalid_quote")
                 return None
             valid_until = int(valid_until)
-            return {
+            quote = {
                 "quoteId": data["quoteId"],
                 "ratio": float(data["ratio"]),
                 "inverseRatio": float(data["inverseRatio"]),
@@ -214,6 +214,9 @@ def get_quote(from_asset: str, to_asset: str, amount: float) -> Optional[Dict[st
                 "validUntil": valid_until,
                 "created_at": time.time(),
             }
+            quote["fromToken"] = from_asset
+            quote["toToken"] = to_asset
+            return quote
         else:
             logger.warning(
                 f"❌ No valid quote returned for {from_asset} → {to_asset}: {data}"


### PR DESCRIPTION
## Summary
- add source/target tokens to get_quote response to prevent missing token data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ded600f388329b27cbe2829a8366d