### PR TITLE
Handle alternate quote token keys

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -308,8 +308,8 @@ def accept_quote(
         from_token = from_token or pair.get("from")
         to_token = to_token or pair.get("to")
 
-    from_token = from_token or quote.get("fromToken")
-    to_token = to_token or quote.get("toToken")
+    from_token = from_token or quote.get("fromToken") or quote.get("from_token")
+    to_token = to_token or quote.get("toToken") or quote.get("to_token")
 
     if not from_token or not to_token:
         logger.warning(


### PR DESCRIPTION
## Summary
- support both camelCase and snake_case token keys in accept_quote
- add empty convert history log file

## Testing
- `pytest`
- `python -m py_compile convert_api.py`


------
https://chatgpt.com/codex/tasks/task_e_688fa8054bfc8329a661dd6e2948fc2b