### PR TITLE
Use fromAsset and toAsset in accept_quote

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -308,8 +308,22 @@ def accept_quote(
         from_token = from_token or pair.get("from")
         to_token = to_token or pair.get("to")
 
-    from_token = from_token or quote.get("fromToken") or quote.get("from_token")
-    to_token = to_token or quote.get("toToken") or quote.get("to_token")
+    from_token = (
+        from_token
+        or quote.get("fromAsset")
+        or quote.get("fromToken")
+        or quote.get("from_token")
+    )
+    to_token = (
+        to_token
+        or quote.get("toAsset")
+        or quote.get("toToken")
+        or quote.get("to_token")
+    )
+
+    logger.debug(
+        f"[dev3] 🔍 accept_quote(): from_token={from_token}, to_token={to_token}, keys={list(quote.keys())}"
+    )
 
     if not from_token or not to_token:
         logger.warning(


### PR DESCRIPTION
## Summary
- handle Binance Convert API responses using `fromAsset`/`toAsset`
- keep fallback to previous `fromToken`/`toToken` keys and log token resolution

## Testing
- `python -m py_compile convert_api.py`


------
https://chatgpt.com/codex/tasks/task_e_688faa24605c832989d6433fa052dc56