### PR TITLE
Ensure token info retrieval during conversions

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -4,7 +4,8 @@ import json
 import os
 from typing import List, Dict, Any
 
-from convert_api import get_quote, accept_quote, get_balances, get_token_info
+from convert_api import get_quote, accept_quote, get_balances
+from convert_api import get_token_info
 from binance_api import get_binance_balances
 from convert_notifier import notify_success, notify_failure
 from convert_filters import passes_filters


### PR DESCRIPTION
## Summary
- Split convert_api imports in convert_cycle so get_token_info is explicitly imported

## Testing
- `python -m py_compile convert_cycle.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fb6987ac083298358bb2120d276bc