### PR TITLE
Improve token info retrieval with fallback

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -506,14 +506,3 @@ def get_valid_quote(from_token: str, to_token: str, from_amount: float) -> Optio
             level="error",
         )
         return None
-
-def get_token_info(token_key: str):
-    """
-    Повертає інформацію про токен у форматі {"symbol": token_key}.
-    Якщо ключ порожній або некоректний — повертає None.
-    """
-    if not token_key or not isinstance(token_key, str):
-        logger.warning(f"[dev3] ⚠️ Невалідний ключ токена: {token_key}")
-        return None
-    logger.debug(f"[dev3] ℹ️ get_token_info(): token_key = {token_key}")
-    return {"symbol": token_key}

--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -5,10 +5,9 @@ import os
 from typing import List, Dict, Any
 
 from convert_api import get_quote, accept_quote, get_balances
-from convert_api import get_token_info
 from binance_api import get_binance_balances
 from convert_notifier import notify_success, notify_failure
-from convert_filters import passes_filters
+from convert_filters import passes_filters, get_token_info
 from convert_logger import (
     logger,
     save_convert_history,

--- a/convert_filters.py
+++ b/convert_filters.py
@@ -4,7 +4,7 @@ import json
 from typing import Dict, Tuple, List, Any
 
 from convert_logger import logger
-from binance_api import get_spot_price, get_ratio
+from binance_api import get_spot_price, get_ratio, get_lot_step, get_precision
 from utils_dev3 import safe_float
 
 
@@ -16,6 +16,63 @@ def get_ratio_from_spot(from_token: str, to_token: str) -> float:
 MIN_SCORE = -0.0005
 
 HISTORY_FILE = os.path.join("logs", "convert_history.json")
+
+
+_token_limits_cache: Dict[str, Dict[str, Any]] | None = None
+_logged_missing_tokens: set[str] = set()
+
+
+def _load_token_limits() -> Dict[str, Dict[str, Any]]:
+    """Lazy-load token limits from ``quote_limits.json``."""
+    global _token_limits_cache
+    if _token_limits_cache is None:
+        try:
+            with open("quote_limits.json", "r", encoding="utf-8") as f:
+                _token_limits_cache = json.load(f)
+        except Exception as exc:  # pragma: no cover - file issues
+            logger.warning("[dev3] ❌ Не вдалося прочитати quote_limits.json: %s", exc)
+            _token_limits_cache = {}
+    return _token_limits_cache
+
+
+def _log_missing_token(token: str) -> None:
+    """Persist the name of tokens missing from ``quote_limits.json``."""
+    if not token or token in _logged_missing_tokens:
+        return
+    path = os.path.join("logs", "missing_tokens.log")
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(token + "\n")
+        _logged_missing_tokens.add(token)
+    except Exception as exc:  # pragma: no cover - diagnostics
+        logger.warning("[dev3] ❌ Не вдалося записати відсутній токен %s: %s", token, exc)
+
+
+def get_token_info(token_key: str) -> Dict[str, Any] | None:
+    """Return token metadata with fallback values and detailed logging."""
+    if not token_key or not isinstance(token_key, str):
+        logger.warning("[dev3] ⚠️ Невалідний ключ токена: %s", token_key)
+        return None
+
+    token_key = token_key.upper()
+    limits = _load_token_limits()
+    info = limits.get(token_key)
+    if info:
+        info.setdefault("symbol", token_key)
+        return info
+
+    logger.info("[dev3] ℹ️ Токен %s відсутній у quote_limits.json", token_key)
+    _log_missing_token(token_key)
+
+    try:
+        lot = get_lot_step(token_key)
+        step = float(lot.get("stepSize", 1))
+        decimals = get_precision(token_key)
+        return {"symbol": token_key, "minQty": 1, "stepSize": step, "decimals": decimals}
+    except Exception as exc:  # pragma: no cover - network
+        logger.warning("[dev3] ❌ Fallback для %s провалився: %s", token_key, exc)
+        return {"symbol": token_key, "minQty": 1, "stepSize": 1, "decimals": 0}
 
 
 def filter_top_tokens(
@@ -72,8 +129,8 @@ def passes_filters(score: float, quote: Dict[str, Any], balance: float) -> Tuple
     if to_amount <= from_amount:
         return False, "no_profit"
 
-    from_token = quote.get("fromAsset")
-    to_token = quote.get("toAsset")
+    from_token = quote.get("fromAsset") or quote.get("fromToken")
+    to_token = quote.get("toAsset") or quote.get("toToken")
     if not from_token or not to_token:
         logger.warning(
             "[dev3] ❌ Один із токенів None: from_token=%s, to_token=%s",


### PR DESCRIPTION
## Summary
- Add detailed token info loader with logging, fallback to Binance exchange info, and missing-token logging
- Ensure filters use token identifiers from either `fromAsset/toAsset` or `fromToken/toToken`
- Pull `get_token_info` from filters module

## Testing
- `python -m py_compile convert_filters.py convert_cycle.py convert_api.py`


------
https://chatgpt.com/codex/tasks/task_e_688fb85768648329868abc73d2e8c6ea