### PR TITLE
fix: correct convert history path

### DIFF
--- a/train_convert_model.py
+++ b/train_convert_model.py
@@ -32,7 +32,7 @@ from convert_model import (
 )
 
 MODEL_PATH = "model_convert.joblib"
-HISTORY_PATH = "logs/convert_history.json"
+HISTORY_PATH = "convert_history.json"
 
 
 def load_convert_history(path: str = "convert_history.json") -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- read convert history from root-level `convert_history.json`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891deab9e64832983d030234825a941