### PR TITLE
Allow high-score trades with low spot ratios

### DIFF
--- a/convert_filters.py
+++ b/convert_filters.py
@@ -112,7 +112,7 @@ def passes_filters(score: float, quote: Dict[str, Any], balance: float) -> Tuple
     spot_ratio = get_ratio(from_symbol, to_symbol)
     if spot_ratio <= 0:
         return False, "spot_ratio_failed"
-    if spot_ratio <= 1.0:
+    if spot_ratio <= 1.0 and score < 2.0:
         return False, "spot_no_profit"
 
     if to_usdt_value < 0.5:


### PR DESCRIPTION
## Summary
- allow conversions with score ≥ 2.0 even when spot ratio ≤ 1.0

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68933cd0e8d88329989778b38cfa62e0