### PR TITLE
Enable fallback conversions for 'no_profit' cases

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -359,7 +359,8 @@ def process_top_pairs(pairs: List[Dict[str, Any]] | None = None) -> None:
 
         valid, reason = passes_filters(score, quote, amount)
         if not valid:
-            if reason == "spot_no_profit" and score > 0:
+            # Уніфікуємо причини: no_profit і spot_no_profit трактуємо однаково
+            if reason in ("spot_no_profit", "no_profit") and score > 0:
                 fallback_candidates.append((from_token, to_token, amount, quote, score))
                 logger.info(
                     safe_log(


### PR DESCRIPTION
## Summary
- Treat `no_profit` the same as `spot_no_profit` when collecting fallback candidates

## Testing
- `python -m pytest`
- `python daily_analysis.py --mode convert` *(fails: ModuleNotFoundError: No module named 'config_dev3')*
- `python run_convert_trade.py` *(fails: ModuleNotFoundError: No module named 'config_dev3')*

------
https://chatgpt.com/codex/tasks/task_e_6895be3a22588329b076bc52b5a3228c