### PR TITLE
Improve convert diagnostics and add quote debug tool

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -17,6 +17,7 @@ from convert_logger import (
     log_conversion_success,
     log_conversion_error,
     log_quote_skipped,
+    safe_log,
 )
 from binance_api import (
     get_spot_price,
@@ -354,8 +355,14 @@ def accept_quote(
             final_status = order_status.get("orderStatus")
 
     if final_status == "SUCCESS":
-        profit = safe_float(order_status.get("toAmount", 0)) - safe_float(
-            order_status.get("fromAmount", 0)
+        from_amt = safe_float(order_status.get("fromAmount", 0))
+        to_amt = safe_float(order_status.get("toAmount", 0))
+        profit = to_amt - from_amt
+        logger.info(
+            safe_log(
+                f"[dev3] ✅ accept_quote result: {from_token}->{to_token} "
+                f"fromAmount={from_amt} toAmount={to_amt} profit={profit}"
+            )
         )
         log_conversion_success(from_token, to_token, profit)
         logger.info(f"[dev3] 🔄 accept_quote виконано: {quote_id}")

--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -359,20 +359,19 @@ def process_top_pairs(pairs: List[Dict[str, Any]] | None = None) -> None:
 
         valid, reason = passes_filters(score, quote, amount)
         if not valid:
-            # Уніфікуємо причини: no_profit і spot_no_profit трактуємо однаково
-            if reason in ("spot_no_profit", "no_profit") and score > 0:
+            logger.info(
+                safe_log(
+                    f"[dev3] ⛔️ Пропуск {from_token} → {to_token}: score={score:.4f}, причина={reason}, quote={quote}"
+                )
+            )
+            if reason == "spot_no_profit" and score > 0:
                 fallback_candidates.append((from_token, to_token, amount, quote, score))
                 logger.info(
                     safe_log(
-                        f"[dev3] ⚠ Навчальна пара: {from_token} → {to_token} (score={score:.4f})"
+                        f"[dev3] ⚠ Додаємо до навчальних: {from_token} → {to_token} (score={score:.4f})"
                     )
                 )
                 continue
-            logger.info(
-                safe_log(
-                    f"[dev3] ⛔️ Пропуск {from_token} → {to_token}: причина={reason}, quote={quote}"
-                )
-            )
             continue
 
         if try_convert(from_token, to_token, amount, score, quote):

--- a/tools/quote_debug.py
+++ b/tools/quote_debug.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import sys
+import json
+from pathlib import Path
+
+# Ensure repository root is in sys.path for module imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from convert_api import get_quote
+from convert_filters import passes_filters
+from convert_model import predict
+from convert_logger import logger, safe_log
+from utils_dev3 import safe_float
+
+
+def main():
+    if len(sys.argv) < 4:
+        print("Usage: quote_debug.py FROM_TOKEN TO_TOKEN AMOUNT")
+        sys.exit(1)
+    f, t, a = sys.argv[1], sys.argv[2], float(sys.argv[3])
+    q = get_quote(f, t, a)
+    exp, prob, score = predict(f, t, q)
+    ok, reason = passes_filters(score, q, a)
+    logger.info(
+        safe_log(
+            f"[dev3] 🔍 quote_debug {f}->{t}: ok={ok}, reason={reason}, "
+            f"score={score:.4f}, exp_profit={safe_float(exp):.4f}, quote={json.dumps(q, ensure_ascii=False)}"
+        )
+    )
+    print(
+        json.dumps(
+            {
+                "ok": ok,
+                "reason": reason,
+                "score": float(score),
+                "expected_profit": float(exp),
+                "quote": q,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add detailed logging in `passes_filters` for quote diagnostics and explicit no-profit verdicts
- log skip reasons in `convert_cycle` and restrict training fallbacks to spot no-profit cases
- record amounts and profit when accepting quotes
- add `tools/quote_debug.py` utility for inspecting individual quotes

## Testing
- `python -m py_compile convert_filters.py convert_cycle.py convert_api.py tools/quote_debug.py`
- `./tools/quote_debug.py BTTC LUMIA 70366737.1` *(fails: No module named 'config_dev3')*

------
https://chatgpt.com/codex/tasks/task_e_6895c2f2a534832985e10ac9f98050a0