### PR TITLE
feat: add explore min edge filtering

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -21,6 +21,8 @@ from quote_counter import should_throttle, reset_cycle
 from convert_model import _hash_token, predict
 from utils_dev3 import safe_float
 
+EXPLORE_MIN_EDGE = safe_float(os.environ.get("EXPLORE_MIN_EDGE", 0.0))
+
 
 def _metric_value(val: Any) -> float:
     """Return float metric from raw value or nested dict."""
@@ -412,7 +414,9 @@ def process_top_pairs(pairs: List[Dict[str, Any]] | None = None) -> None:
                 break
             min_required = get_min_convert_amount(f_token, t_token)
             explore_amt = max(min_required * EXPLORE_MIN_LOT_FACTOR, min_required)
-            ok, reason = passes_filters(0.01, q, explore_amt, force_spot=True, min_edge=0.0)
+            ok, reason = passes_filters(
+                0.01, q, explore_amt, force_spot=True, min_edge=EXPLORE_MIN_EDGE
+            )
             if not ok:
                 logger.info(safe_log(f"[dev3] ⛔️ Explore skip {f_token}→{t_token}: {reason}"))
                 continue

--- a/convert_filters.py
+++ b/convert_filters.py
@@ -106,7 +106,7 @@ def passes_filters(
             safe_log(
                 f"[dev3] 🔎 passes_filters dbg: {_from}->{_to} "
                 f"score={score:.4f} ratio={ratio} inv={inv} "
-                f"fromAmount={fa} toAmount={ta} spot={spot}"
+                f"fromAmount={fa} toAmount={ta} spot={spot} min_edge={min_edge:.4f}"
             )
         )
     except Exception as e:
@@ -140,6 +140,12 @@ def passes_filters(
         if not force_spot:
             return False, "spot_no_profit"
         if (r_spot - r_convert) <= min_edge * max(r_spot, r_convert):
+            edge = (r_spot - r_convert) / max(r_spot, r_convert)
+            logger.info(
+                safe_log(
+                    f"[dev3] \U0001F515 spot_edge too small: edge={edge:.6f} < min_edge={min_edge:.6f}"
+                )
+            )
             return False, "spot_edge_too_small"
         return True, "explore_spot_positive"
 


### PR DESCRIPTION
## Summary
- read `EXPLORE_MIN_EDGE` from environment
- pass min_edge into explore `passes_filters` calls and include in diagnostics
- log actual edge when spot edge is too small

## Testing
- `python3 -m py_compile convert_cycle.py convert_filters.py convert_api.py`
- `EXPLORE_MODE=1 EXPLORE_PAPER=1 EXPLORE_MAX=5 EXPLORE_MIN_EDGE=0.02 EXPLORE_MIN_LOT_FACTOR=1.0 /usr/bin/python3 run_convert_trade.py`
- `egrep -n "passes_filters dbg" logs/convert_trade.log | awk '{for(i=1;i<=NF;i++){if($i~/^inv=/){sub("inv=","",$i);inv=$i} if($i~/^spot=/){sub("spot=","",$i);spot=$i}} maxv=(spot>inv?spot:inv); edge=(spot-inv)/maxv; print edge}' | awk '{c++; if($1>=0.02) ge++; else lt++;} END{printf ">=min_edge=%d  <min_edge=%d  total=%d\n", ge, lt, c}'`
- `egrep -n "\[PAPER\]|\baccept_quote\b|orderId|order_status" logs/convert_trade.log | tail -n 50`


------
https://chatgpt.com/codex/tasks/task_e_6895d37909bc8329860940ecaed34f26