### PR TITLE
feat: enable explore-mode edge-based fallback

### DIFF
--- a/convert_filters.py
+++ b/convert_filters.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple, Any
 from convert_logger import logger, safe_log
 from binance_api import get_spot_price, get_ratio, get_lot_step, get_precision
 from utils_dev3 import safe_float
+import os
 
 
 def get_ratio_from_spot(from_token: str, to_token: str) -> float:
@@ -15,6 +16,17 @@ def get_ratio_from_spot(from_token: str, to_token: str) -> float:
 
 # Allow slight negative scores and smaller toAmount for training trades
 MIN_SCORE = -0.0005
+
+EXPLORE_MODE = int(os.getenv("EXPLORE_MODE", "0"))
+EXPLORE_PAPER = int(os.getenv("EXPLORE_PAPER", "0"))
+EXPLORE_MIN_EDGE = float(os.getenv("EXPLORE_MIN_EDGE", "0.001"))
+
+
+def _compute_edge(spot_inverse: float, quote_inverse: float) -> float:
+    """Positive edge if convert better than spot."""
+    if spot_inverse <= 0:
+        return -1.0
+    return (spot_inverse - quote_inverse) / spot_inverse
 
 HISTORY_FILE = os.path.join("logs", "convert_history.json")
 
@@ -112,13 +124,6 @@ def passes_filters(
     except Exception as e:
         logger.warning(safe_log(f"[dev3] ⚠️ passes_filters dbg failed: {e}"))
 
-    if score < MIN_SCORE:
-        return False, "low_score"
-
-    # Стандартний зріз по моделі, але в explore режимі дозволяємо спиратись на спот
-    if score <= 0 and not force_spot:
-        return False, "no_profit"
-
     from_amount = safe_float(quote.get("fromAmount", 0))
     to_amount = safe_float(quote.get("toAmount", 0))
 
@@ -132,18 +137,31 @@ def passes_filters(
         )
         return False, "invalid_tokens"
 
-    # Перевірка по споту: якщо конверт гірший за спот — відсікаємо (або дозволяємо в explore)
     r_convert = safe_float(quote.get("ratio", 0))
-    r_spot = get_ratio(from_token, to_token) or get_spot_price(from_token, to_token)
-    r_spot = safe_float(r_spot)
+    r_spot = get_ratio(from_token, to_token)
+    spot_inv = 1 / r_spot if r_spot else 0
+    quote_inv = 1 / r_convert if r_convert else 0
+    edge = _compute_edge(spot_inv, quote_inv)
+
+    if EXPLORE_MODE:
+        if edge >= EXPLORE_MIN_EDGE:
+            return True, "ok_explore"
+        return False, "edge_too_small_explore"
+
+    if score < MIN_SCORE:
+        return False, "low_score"
+
+    if edge <= 0 and not force_spot:
+        return False, "no_profit"
+
     if r_spot and r_convert and r_convert < r_spot:
         if not force_spot:
             return False, "spot_no_profit"
         if (r_spot - r_convert) <= min_edge * max(r_spot, r_convert):
-            edge = (r_spot - r_convert) / max(r_spot, r_convert)
+            edge_val = (r_spot - r_convert) / max(r_spot, r_convert)
             logger.info(
                 safe_log(
-                    f"[dev3] \U0001F515 spot_edge too small: edge={edge:.6f} < min_edge={min_edge:.6f}"
+                    f"[dev3] \U0001F515 spot_edge too small: edge={edge_val:.6f} < min_edge={min_edge:.6f}"
                 )
             )
             return False, "spot_edge_too_small"

--- a/run_convert_trade.py
+++ b/run_convert_trade.py
@@ -7,6 +7,19 @@ from convert_cycle import process_top_pairs
 from convert_logger import logger, safe_log
 from quote_counter import can_request_quote
 
+EXPLORE_MODE = int(os.getenv("EXPLORE_MODE", "0"))
+EXPLORE_PAPER = int(os.getenv("EXPLORE_PAPER", "1"))
+EXPLORE_MAX = int(os.getenv("EXPLORE_MAX", "2"))
+EXPLORE_MIN_EDGE = float(os.getenv("EXPLORE_MIN_EDGE", "0.001"))
+EXPLORE_MIN_LOT_FACTOR = float(os.getenv("EXPLORE_MIN_LOT_FACTOR", "0.5"))
+
+logger.info(
+    safe_log(
+        f"[dev3] Explore: MODE={EXPLORE_MODE} PAPER={EXPLORE_PAPER} MAX={EXPLORE_MAX} "
+        f"MIN_EDGE={EXPLORE_MIN_EDGE} MIN_LOT_FACTOR={EXPLORE_MIN_LOT_FACTOR}"
+    )
+)
+
 if not can_request_quote():
     logger.warning(safe_log("[dev3] ⛔ Ліміт запитів до Convert API досягнуто. Пропускаємо цикл."))
     exit(0)


### PR DESCRIPTION
## Summary
- filter invalid fiat pairs and illiquid symbols in daily analysis
- introduce explore-mode environment controls with edge-based passes
- add edge-driven fallback conversion for explore mode
- log explore parameters during trade run

## Testing
- `python -m py_compile daily_analysis.py convert_filters.py convert_cycle.py run_convert_trade.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896e805478c832988fa0dfbca0fe1ad