### PR TITLE
Refactor convert API to use Binance SAPI endpoints and respect quote limits

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -501,6 +501,7 @@ def process_top_pairs(
             log_quote_skipped(from_token, to_token, "invalid_quote")
             stats["no_quote"] += 1
             continue
+        quote_count += 1
 
         expected_profit, prob_up, score = predict(from_token, to_token, quote)
         logger.info(


### PR DESCRIPTION
## Summary
- Replace deprecated client calls with direct Binance Convert SAPI REST requests, including HMAC signing and retry logic
- Normalize quote, accept, and order status responses and expose polling constants
- Count each quote request in the cycle to enforce per-cycle limits

## Testing
- `python -m py_compile convert_api.py convert_cycle.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689adedd4b888329ba3a2f8bb5a11866