### PR TITLE
Refactor Binance secret key usage

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Dict, Any
 
 import requests
 from binance.client import Client
-from config_dev3 import BINANCE_API_KEY, BINANCE_SECRET_KEY
+from config_dev3 import BINANCE_API_KEY, BINANCE_API_SECRET
 
 from convert_logger import logger
 
@@ -14,7 +14,7 @@ _session = requests.Session()
 
 # Return authenticated Binance client
 def get_binance_client():
-    return Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_SECRET_KEY)
+    return Client(api_key=BINANCE_API_KEY, api_secret=BINANCE_API_SECRET)
 
 # Cache for spot prices: {token: (price, timestamp)}
 _price_cache: Dict[str, tuple[float, float]] = {}

--- a/convert_api.py
+++ b/convert_api.py
@@ -9,11 +9,10 @@ from urllib.parse import urlencode
 
 import requests
 
-try:
-    from config_dev3 import BINANCE_API_KEY, BINANCE_SECRET_KEY
-except Exception:  # pragma: no cover - optional keys for tests
-    BINANCE_API_KEY = ""
-BINANCE_SECRET_KEY = ""
+import config_dev3 as cfg
+BINANCE_API_KEY = cfg.BINANCE_API_KEY
+BINANCE_API_SECRET = cfg.BINANCE_API_SECRET
+BINANCE_SECRET_KEY = cfg.BINANCE_API_SECRET  # сумісність зі старим кодом
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +69,7 @@ def _sign(params: Dict[str, Any]) -> str:
     params["timestamp"] = _ts()
     query = urlencode(params, doseq=True)
     signature = hmac.new(
-        BINANCE_SECRET_KEY.encode("utf-8"),
+        BINANCE_API_SECRET.encode("utf-8"),
         query.encode("utf-8"),
         hashlib.sha256,
     ).hexdigest()


### PR DESCRIPTION
## Summary
- replace BINANCE_SECRET_KEY references with BINANCE_API_SECRET
- expose BINANCE_API_SECRET and alias in convert_api for backward compatibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689c5bcd3b048329ac12cc018f1f613c