### PR TITLE
Use centralized loader for top pairs

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -230,16 +230,17 @@ def get_top_token_pairs(n: int = 5) -> List[Tuple[str, str]]:
         logger.warning("[dev3] top_tokens.json not found")
         return []
     try:
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
+        from run_convert_trade import load_top_pairs
+
+        data = load_top_pairs(path)
     except Exception as exc:  # pragma: no cover - file issues
         logger.warning("[dev3] failed to read top_tokens.json: %s", exc)
         return []
 
     pairs: List[Tuple[str, str]] = []
     for item in data:
-        from_token = item.get("from_token")
-        to_token = item.get("to_token")
+        from_token = item.get("from") or item.get("from_token")
+        to_token = item.get("to") or item.get("to_token")
         if from_token and to_token:
             pairs.append((from_token, to_token))
         if len(pairs) >= n:

--- a/run_convert_trade.py
+++ b/run_convert_trade.py
@@ -58,6 +58,8 @@ def load_top_pairs(path: str) -> list[dict]:
                 **x,
                 "from_token": frm,
                 "to_token": to,
+                "from": frm,
+                "to": to,
                 "edge": edge,
                 "prob": prob,
                 "score": score,


### PR DESCRIPTION
## Summary
- Normalize top pair loading via `load_top_pairs`
- Reuse loader in convert cycle and model helper

## Testing
- `python -m py_compile convert_cycle.py run_convert_trade.py convert_model.py && echo 'py_compile succeeded'`


------
https://chatgpt.com/codex/tasks/task_e_689ce14169548329a41c7fd6c3b2c7bc