### PR TITLE
docs: clarify SPOT-only token balance

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -30,6 +30,7 @@ def get_binance_client():
 
 def get_token_balance(asset: str, wallet: str = "SPOT") -> float:
     """Уніфікований доступ до балансу. FUNDING не використовуємо — повертаємо SPOT."""
+    # ``wallet`` зберігається для сумісності, але завжди використовуємо SPOT.
     if not asset:
         return 0.0
     asset = asset.upper()


### PR DESCRIPTION
## Summary
- clarify that `get_token_balance` always uses SPOT balance and keeps wallet param only for compatibility

## Testing
- `python3 -m py_compile binance_api.py convert_cycle.py run_convert_trade.py convert_model.py convert_filters.py utils_dev3.py`
- `python3 run_convert_trade.py --once --paper` *(fails: ModuleNotFoundError: No module named 'config_dev3')*

------
https://chatgpt.com/codex/tasks/task_e_689ce3d04af083298bce5a5fe672632a