### PR TITLE
Normalize convert pairs and top pair loading

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -30,20 +30,16 @@ def get_binance_client():
 
 def get_token_balance(asset: str, wallet: str = "SPOT") -> float:
     """Уніфікований доступ до балансу. FUNDING не використовуємо — повертаємо SPOT."""
-    # ``wallet`` зберігається для сумісності, але завжди використовуємо SPOT.
-    if not asset:
-        return 0.0
-    asset = asset.upper()
     try:
         client = get_binance_client()
-        bal = client.get_asset_balance(asset=asset)
-        if bal:
-            return float(bal.get("free") or 0.0)
-    except Exception as exc:  # pragma: no cover - network
+        bal = client.get_asset_balance(asset=asset.upper())
+        free = bal.get("free") if bal else 0.0
+        return float(free or 0.0)
+    except Exception as e:  # pragma: no cover - network
         logger.warning(
-            f"[dev3] get_token_balance fallback SPOT: asset={asset} err={exc}"
+            "❌ get_token_balance fallback: %s wallet=%s err=%s", asset, wallet, e
         )
-    return 0.0
+        return 0.0
 
 try:
     from config_dev3 import VALID_PAIRS

--- a/convert_filters.py
+++ b/convert_filters.py
@@ -16,6 +16,57 @@ from convert_api import get_quote_raw
 
 CANDIDATE_WALLETS = ["SPOT_FUNDING", "SPOT", "FUNDING"]
 
+REQUIRED_KEYS = ("from", "to", "amount_quote")
+
+
+def _pair_has_required_fields(p: dict) -> bool:
+    """Приймає як нові ключі (from/to/amount_quote), так і бексові (from_token/to_token/amount, amountQuote)."""
+    from_sym = p.get("from") or p.get("from_token")
+    to_sym = p.get("to") or p.get("to_token")
+    amt = (
+        p.get("amount_quote")
+        or p.get("quote_amount")
+        or p.get("amountQuote")
+        or p.get("amount")
+        or 0.0
+    )
+    try:
+        amt = float(amt or 0.0)
+    except Exception:
+        amt = 0.0
+    return bool(from_sym and to_sym and amt > 0)
+
+
+DEFAULT_WALLET = "SPOT"
+MIN_QUOTE_DEFAULT = 11.0
+
+
+def normalize_pair(p: dict) -> dict:
+    """Повертає пару у канонічному вигляді для конверта."""
+    out = {
+        "from": (p.get("from") or p.get("from_token") or "").upper(),
+        "to": (p.get("to") or p.get("to_token") or "USDT").upper(),
+        "wallet": (p.get("wallet") or DEFAULT_WALLET).upper(),
+        "score": float(p.get("score") or 0.0),
+        "prob": float(p.get("prob") or p.get("prob_up") or 0.0),
+        "edge": float(p.get("edge") or p.get("expected_profit") or 0.0),
+    }
+    amt = (
+        p.get("amount_quote")
+        or p.get("quote_amount")
+        or p.get("amountQuote")
+        or p.get("amount")
+        or 0.0
+    )
+    try:
+        amt = float(amt)
+    except Exception:
+        amt = 0.0
+    if amt <= 0:
+        amt = MIN_QUOTE_DEFAULT
+    out["amount_quote"] = amt
+    return out
+
 
 def _safe_pick_upper(raw: dict, keys: list[str]) -> str | None:
     """Return first non-empty value from ``raw[keys]`` stripped and uppercased."""

--- a/convert_model.py
+++ b/convert_model.py
@@ -9,6 +9,7 @@ import numpy as np
 import joblib
 import pandas as pd
 from utils_dev3 import safe_float
+from run_convert_trade import load_top_pairs
 
 MODEL_PATH = "model_convert.joblib"
 logger = logging.getLogger(__name__)
@@ -225,18 +226,7 @@ def predict(
 
 def get_top_token_pairs(n: int = 5) -> List[Tuple[str, str]]:
     """Return top token pairs from top_tokens.json."""
-    path = os.path.join(os.path.dirname(__file__), "top_tokens.json")
-    if not os.path.exists(path):
-        logger.warning("[dev3] top_tokens.json not found")
-        return []
-    try:
-        from run_convert_trade import load_top_pairs
-
-        data = load_top_pairs(path)
-    except Exception as exc:  # pragma: no cover - file issues
-        logger.warning("[dev3] failed to read top_tokens.json: %s", exc)
-        return []
-
+    data = load_top_pairs("top_tokens.json")
     pairs: List[Tuple[str, str]] = []
     for item in data:
         from_token = item.get("from") or item.get("from_token")


### PR DESCRIPTION
## Summary
- centralize pair normalization and required field checks
- add shared top pair loader for convert cycle and model
- harden Binance balance lookup with safe fallback

## Testing
- `python -m py_compile convert_filters.py run_convert_trade.py convert_cycle.py convert_model.py binance_api.py`

------
https://chatgpt.com/codex/tasks/task_e_689d9465e48083299d3f1223480499e5