### PR TITLE
Normalize convert pair handling and avoid zero-amount quotes

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -10,6 +10,7 @@ import joblib
 import pandas as pd
 from utils_dev3 import safe_float
 from run_convert_trade import load_top_pairs
+from convert_filters import normalize_pair, validate_pair
 
 MODEL_PATH = "model_convert.joblib"
 logger = logging.getLogger(__name__)
@@ -229,10 +230,22 @@ def get_top_token_pairs(n: int = 5) -> List[Tuple[str, str]]:
     data = load_top_pairs("top_tokens.json")
     pairs: List[Tuple[str, str]] = []
     for item in data:
-        from_token = item.get("from") or item.get("from_token")
-        to_token = item.get("to") or item.get("to_token")
+        from_token = item.get("from")
+        to_token = item.get("to")
         if from_token and to_token:
             pairs.append((from_token, to_token))
         if len(pairs) >= n:
             break
     return pairs
+
+
+def load_pairs_for_training(path: str = "top_tokens.json") -> List[Dict[str, Any]]:
+    MIN_QUOTE = max(11.0, globals().get("MIN_NOTIONAL", 0.0) or 0.0)
+    raw = json.load(open(path, "r", encoding="utf-8"))
+    out: List[Dict[str, Any]] = []
+    for r in raw:
+        p = normalize_pair(r, MIN_QUOTE)
+        ok, _ = validate_pair(p)
+        if ok:
+            out.append(p)
+    return out


### PR DESCRIPTION
## Summary
- centralize pair normalization/validation to unify keys and minimum quote amounts
- guard Binance balance and quote calls against non-positive amounts
- use normalized pairs across trade, cycle, and model modules with clearer skip logging

## Testing
- `python -m py_compile convert_filters.py binance_api.py run_convert_trade.py convert_cycle.py convert_model.py`


------
https://chatgpt.com/codex/tasks/task_e_689d99147a888329ba291bc1ef742b46