### PR TITLE
Refactor Binance convert helpers with caching and safer requests

### DIFF
--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -611,10 +611,9 @@ def process_top_pairs(pairs: List[Dict[str, Any]] | None = None, config: Dict[st
     logger.info(
         "[dev3] 🔍 Запуск process_top_pairs з %d парами", len(pairs) if pairs else 0
     )
-    _sync_time()
 
     for pair in pairs or []:
-        amount_quote = float(pair["amount_quote"])
+        from_amount = float(pair["amount_quote"])
         from_sym = pair["from"]
         to_sym = pair["to"]
         wallet = pair.get("wallet", "SPOT")
@@ -623,25 +622,25 @@ def process_top_pairs(pairs: List[Dict[str, Any]] | None = None, config: Dict[st
             from_sym,
             to_sym,
             wallet,
-            amount_quote,
+            from_amount,
         )
         quote = pair.get("quote") or get_quote(
             from_asset=from_sym,
             to_asset=to_sym,
-            amount_quote=amount_quote,
+            from_amount=from_amount,
             wallet=wallet,
         )
-        if not quote:
+        if not quote or not quote.get("quoteId"):
             logger.info("⏭️  convert skipped (no_quote): %s", pair)
             continue
         wtype = wallet
-        acc = accept_quote_raw(quote.get("quoteId")) if quote else None
+        acc = accept_quote_raw(quote.get("quoteId"))
         if acc and acc.get("status") == 200:
             trade_logger.info(
                 "[dev3] ✅ Конверсія %s→%s amount=%s wallet=%s result=%s",
                 from_sym,
                 to_sym,
-                amount_quote,
+                from_amount,
                 wtype,
                 acc.get("json") if isinstance(acc, dict) else acc,
             )

--- a/convert_model.py
+++ b/convert_model.py
@@ -45,9 +45,15 @@ def prepare_dataset(history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         df = df[df["expected_profit"].notnull()]
 
     if "accepted" in df.columns:
-        df["executed"] = df["accepted"].fillna(False).astype(bool)
+        df["executed"] = df["accepted"].fillna(False)
+        if df["executed"].dtype == "object":
+            df["executed"] = df["executed"].infer_objects(copy=False)
+        df["executed"] = df["executed"].astype(bool)
     elif "success" in df.columns:
-        df["executed"] = df["success"].fillna(False).astype(bool)
+        df["executed"] = df["success"].fillna(False)
+        if df["executed"].dtype == "object":
+            df["executed"] = df["executed"].infer_objects(copy=False)
+        df["executed"] = df["executed"].astype(bool)
     else:
         df["executed"] = False
 

--- a/run_convert_trade.py
+++ b/run_convert_trade.py
@@ -5,7 +5,6 @@ import json
 from pathlib import Path
 
 from convert_logger import logger, safe_log
-from convert_api import _sync_time
 from quote_counter import can_request_quote
 from utils_dev3 import safe_float
 from convert_filters import normalize_pair
@@ -84,7 +83,6 @@ def cleanup() -> None:
 
 def main() -> None:
     cleanup()
-    _sync_time()
     logger.info(safe_log("[dev3] 🔄 Запуск convert трейдингу"))
     try:
         from convert_cycle import process_top_pairs

--- a/utils_dev3.py
+++ b/utils_dev3.py
@@ -2,10 +2,31 @@ import json
 import os
 import time
 import re
+import logging
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, List
 from json_sanitize import safe_load_json
+
+try:  # Optional config overrides
+    from config_dev3 import BINANCE_BASE_URL as _CFG_BASE_URL, USE_BINANCE_US
+except Exception:  # pragma: no cover - optional config
+    _CFG_BASE_URL = ""
+    USE_BINANCE_US = False
+
+# Base URL resolution with US flag handling
+logger = logging.getLogger("dev3")
+BINANCE_BASE_URL = _CFG_BASE_URL or (
+    "https://api.binance.us" if USE_BINANCE_US else "https://api.binance.com"
+)
+
+# Convert may be unavailable on Binance US
+CONVERT_ENABLED = True
+if USE_BINANCE_US and not _CFG_BASE_URL:
+    logger.warning(
+        "[dev3] ⚠️ Binance US selected; Convert API may be unavailable"
+    )
+    CONVERT_ENABLED = False
 
 # ---- Конфіг нормалізації активів для Convert (без хардкоду) ----
 _ASSET_CFG_PATH = "convert_assets_config.json"


### PR DESCRIPTION
## Summary
- add configurable Binance base URL with US flag handling
- rewrite convert API wrapper with signed query requests, caching and legacy compatibility
- rate-limit convert filters and normalize getQuote usage
- handle exchangeInfo caching in analysis and tidy balance helpers

## Testing
- `python3 -m py_compile convert_api.py run_convert_trade.py convert_cycle.py daily_analysis.py binance_api.py convert_model.py tools/quote_debug.py quote_counter.py convert_logger.py utils_dev3.py convert_filters.py`
- `python3 -c "import convert_api as c; print('ok', bool(c.get_balances('SPOT')))"`
- `python3 -c "import convert_api as c; print(c.get_quote('BTC','USDT','0.0001','SPOT'))"`


------
https://chatgpt.com/codex/tasks/task_e_689f1c2c2e04832999b07be2860b21c9