### PR TITLE
Add tests for Binance Convert API compliance

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -43,3 +43,24 @@ read.
 `accept_quote` is executed only when `ENABLE_LIVE=1` **and** `PAPER=0`.
 Otherwise it logs the skip and returns `{"dryRun": true}`.
 
+## Requirement matrix
+
+| Requirement | Code | Test | Result |
+|-------------|------|------|--------|
+| Convert POST uses `application/x-www-form-urlencoded` and no `json=` | `convert_api._request` / `_headers` | `tests/test_convert_api.py::test_get_quote_uses_form` | ✅ |
+| Backoff & retry on 429/418/5xx and time sync on `-1021` | `convert_api._request` / `_backoff` / `_sync_time` | `tests/test_convert_api.py::test_backoff_on_429`, `test_time_sync_retry` | ✅ |
+| `accept_quote` skipped when not live | `convert_api.accept_quote` | `tests/test_convert_api.py::test_accept_quote_dry_run` | ✅ |
+| Atomic top-token writes with locking and migration of legacy formats | `top_tokens_utils.write_top_tokens_atomic`, `migrate_legacy_if_needed` | `tests/test_top_tokens.py` | ✅ |
+
+## Backoff, limits and dry-run
+
+* Exponential backoff with jitter implemented in `_backoff`.
+* `quote_counter.MAX_PER_CYCLE` limits quote requests to 20 per cycle (override via `MAX_PER_CYCLE`).
+* `accept_quote` performs real conversion only when `ENABLE_LIVE=1` and `PAPER=0`.
+
+## Normalisation & timers
+
+* Pair availability is derived via `get_available_to_tokens` ensuring assets exist on Convert.
+* `systemd/` contains service definitions; production timers (Asia 04:00/04:30/05:45, America 16:00/16:00/17:15) verified separately; no secret files referenced.
+
+

--- a/tests/test_top_tokens.py
+++ b/tests/test_top_tokens.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import os
 import sys
+import threading
 
 sys.path.insert(0, os.getcwd())
 
@@ -31,4 +32,27 @@ def test_migration_and_validation(tmp_path):
     assert migrated["version"] == ttu.TOP_TOKENS_VERSION
     assert migrated["pairs"][0]["from"] == "USDT"
     assert ttu.validate_schema(migrated)
+
+
+def test_concurrent_writes(tmp_path):
+    path = tmp_path / "c.json"
+    data1 = {
+        "version": ttu.TOP_TOKENS_VERSION,
+        "region": "ASIA",
+        "generated_at": 1,
+        "pairs": [{"from": "USDT", "to": "BTC", "score": 1, "edge": 0.1}],
+    }
+    data2 = {
+        "version": ttu.TOP_TOKENS_VERSION,
+        "region": "ASIA",
+        "generated_at": 2,
+        "pairs": [{"from": "USDT", "to": "ETH", "score": 2, "edge": 0.2}],
+    }
+
+    t1 = threading.Thread(target=ttu.write_top_tokens_atomic, args=(str(path), data1))
+    t2 = threading.Thread(target=ttu.write_top_tokens_atomic, args=(str(path), data2))
+    t1.start(); t2.start(); t1.join(); t2.join()
+    final = ttu.read_top_tokens(str(path))
+    assert ttu.validate_schema(final)
+    assert final in (data1, data2)
 


### PR DESCRIPTION
## Summary
- verify form-urlencoded POSTs and dry-run behavior for Binance Convert
- ensure atomic top-token writes under concurrent access
- update audit matrix and docs

## Testing
- `pytest -q`
- `rg -n "requests\.(post|request)\(.*json=" convert_api.py || echo "[ok] json= відсутній у Convert POST"`
- `rg -n "Content-Type:\s*application/x-www-form-urlencoded" convert_api.py`
- `rg -n "/sapi/v1/convert" convert_api.py`
- `rg -n "(OPENAI_API_KEY|BINANCE_API_SECRET|API_SECRET).*print" || echo "[ok] небезпечних print немає"`
- `rg -n "/api/v3/order|/api/v3/myTrades|/api/v3/order/test" || echo "[ok] немає торгових ендпоїнтів Spot"`
- `PAPER=1 ENABLE_LIVE=0 DISABLE_GPT=1 python3 - <<'PY'\nfrom convert_api import get_quote_with_id\nq = get_quote_with_id("USDT","BTC",10.0)\nprint({"quoteId": q.get("quoteId"), "ratio": q.get("ratio"), "toAmount": q.get("toAmount"), "validTimestamp": q.get("validTimestamp")})\nPY`
- `PAPER=1 ENABLE_LIVE=0 python3 - <<'PY'\nfrom convert_api import get_quote_with_id\nok=fail=0\nfor i in range(25):\n    try:\n        get_quote_with_id("USDT","BTC",10.0); ok+=1\n    except Exception:\n        fail+=1\nprint({"quotes_ok": ok, "quotes_failed": fail})\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68b2ae89e1a0832985c592080edec286