### PR TITLE
Enable PAPER mode stubs for offline quote testing

### DIFF
--- a/quote_counter.py
+++ b/quote_counter.py
@@ -74,6 +74,8 @@ def increment_quote_usage() -> int:
 
 def can_request_quote() -> bool:
     """Return True if current quote count is below the limit."""
+    if os.getenv("PAPER", "0") == "1":
+        return True
     return get_count() < QUOTE_LIMIT
 
 


### PR DESCRIPTION
## Summary
- add environment-based PAPER stubs for balances, available tokens, and quotes
- skip quote limits in PAPER mode
- log conversions via unified helper

## Testing
- `pytest`
- `python3 daily_analysis.py`
- `python3 run_convert_trade.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5acb10b108329968aefc8d394b050