### PR TITLE
Ensure DRY-RUN semantics and Binance Convert API compliance

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -240,10 +240,8 @@ def get_quote(from_token: str, to_token: str, amount: float) -> Dict[str, Any]:
 
 def accept_quote(quote_id: str, walletType: Optional[str] = None) -> Dict[str, Any]:
     if os.getenv("PAPER", "1") == "1" or os.getenv("ENABLE_LIVE", "0") != "1":
-        import uuid
-
         logger.info("[dev3] DRY-RUN: acceptQuote skipped for %s", quote_id)
-        return {"orderId": f"paper-{uuid.uuid4().hex}", "createTime": _current_timestamp()}
+        return {"dryRun": True, "msg": "acceptQuote skipped in PAPER/DRY-RUN"}
     params = {"quoteId": quote_id}
     if walletType:
         params["walletType"] = walletType
@@ -281,7 +279,8 @@ def trade_flow(
         params["limit"] = limit
     if cursor is not None:
         params["cursor"] = cursor
-    return _request("GET", "/sapi/v1/convert/tradeFlow", params)
+    data = _request("GET", "/sapi/v1/convert/tradeFlow", params)
+    return {"list": data.get("list", []), "cursor": data.get("cursor")}
 
 
 def get_all_supported_convert_pairs() -> Set[str]:

--- a/convert_cycle.py
+++ b/convert_cycle.py
@@ -90,7 +90,11 @@ def process_pair(from_token: str, to_tokens: List[str], amount: float, score_thr
             accept_result = {"code": None, "msg": str(error)}
 
         order_id = accept_result.get("orderId") if isinstance(accept_result, dict) else None
-        accepted = bool(order_id)
+        accepted = bool(
+            accept_result
+            and order_id
+            and not accept_result.get("dryRun", False)
+        )
         if not accepted and isinstance(accept_result, dict):
             logger.warning(
                 f"[dev3] ❌ Помилка під час accept_quote: {quote['quoteId']} — {accept_result}"
@@ -117,6 +121,7 @@ def process_pair(from_token: str, to_tokens: List[str], amount: float, score_thr
             order_id,
             accept_result if not accepted else None,
             accept_result.get("createTime") if isinstance(accept_result, dict) else None,
+            accept_result.get("dryRun", False) if isinstance(accept_result, dict) else False,
         )
         if accepted:
             any_accepted = True
@@ -134,7 +139,11 @@ def process_pair(from_token: str, to_tokens: List[str], amount: float, score_thr
             accept_result = {"code": None, "msg": str(error)}
 
         order_id = accept_result.get("orderId") if isinstance(accept_result, dict) else None
-        accepted = bool(order_id)
+        accepted = bool(
+            accept_result
+            and order_id
+            and not accept_result.get("dryRun", False)
+        )
         if accepted:
             logger.info(
                 "[dev3] 📊 Навчальна угода успішна: %s orderId=%s createTime=%s",
@@ -159,6 +168,7 @@ def process_pair(from_token: str, to_tokens: List[str], amount: float, score_thr
             order_id,
             accept_result if not accepted else None,
             accept_result.get("createTime") if isinstance(accept_result, dict) else None,
+            accept_result.get("dryRun", False) if isinstance(accept_result, dict) else False,
         )
         if accepted:
             any_accepted = True
@@ -178,6 +188,7 @@ def process_pair(from_token: str, to_tokens: List[str], amount: float, score_thr
                 None,
                 None,
                 None,
+                False,
             )
 
     logger.info("[dev3] ✅ Цикл завершено")

--- a/convert_logger.py
+++ b/convert_logger.py
@@ -111,6 +111,7 @@ def log_conversion_result(
     order_id: str | None = None,
     error: dict | None = None,
     create_time: int | None = None,
+    dry_run: bool = False,
 ) -> None:
     """Log conversion result to history using the unified schema."""
 
@@ -118,17 +119,18 @@ def log_conversion_result(
         "quoteId": quote.get("quoteId"),
         "orderId": order_id,
         "createTime": create_time,
+        "validTime": quote.get("validTime"),
         "from_token": quote.get("fromAsset"),
         "to_token": quote.get("toAsset"),
+        "fromAmount": quote.get("fromAmount"),
+        "toAmount": quote.get("toAmount"),
         "ratio": quote.get("ratio"),
         "inverseRatio": quote.get("inverseRatio"),
-        "from_amount": quote.get("fromAmount"),
-        "to_amount": quote.get("toAmount"),
-        "score": quote.get("score"),
         "expected_profit": quote.get("expected_profit"),
         "prob_up": quote.get("prob_up"),
+        "score": quote.get("score"),
         "accepted": accepted,
-        "error_code": error.get("code") if error else None,
-        "error_msg": error.get("msg") if error else None,
+        "dryRun": dry_run,
+        "error": error,
     }
     log_convert_history(entry)

--- a/docs/binance_audit.md
+++ b/docs/binance_audit.md
@@ -1,11 +1,48 @@
 # Binance Convert API Audit
 
-| Endpoint | Method | Required Params | Signature / Headers | Key Response Fields | Status | Doc Link |
-|---|---|---|---|---|---|---|
-| `/sapi/v1/convert/getQuote` | POST | `fromAsset`, `toAsset`, (`fromAmount` or `toAmount`), `walletType` optional | `timestamp`, `recvWindow`, HMAC SHA256 signature over query, header `X-MBX-APIKEY` | `quoteId`, `ratio`, `inverseRatio`, `fromAmount`, `toAmount` | OK | [Docs](https://developers.binance.com/docs/binance-spot-api-docs/sapi#convert-getQuote) |
-| `/sapi/v1/convert/acceptQuote` | POST | `quoteId`, `walletType` optional | Signed query params and `X-MBX-APIKEY` header | `orderId`, `status`, `fromAsset`, `toAsset` | OK | [Docs](https://developers.binance.com/docs/binance-spot-api-docs/sapi#convert-acceptQuote) |
-| `/sapi/v1/convert/orderStatus` | GET | `orderId` | Signed query params and `X-MBX-APIKEY` header | `orderId`, `status`, `fromAsset`, `toAsset` | OK | [Docs](https://developers.binance.com/docs/binance-spot-api-docs/sapi#convert-orderStatus) |
-| `/sapi/v1/convert/exchangeInfo` | GET | optional `fromAsset`, `toAsset` | Signed query params and `X-MBX-APIKEY` header | `fromAssetList`/`toAssetList` | OK | [Docs](https://developers.binance.com/docs/binance-spot-api-docs/sapi#convert-exchangeInfo) |
-| `/sapi/v1/convert/tradeFlow` | GET | `startTime`, optional `endTime`, `limit`, `fromAsset`, `toAsset` | Signed query params and `X-MBX-APIKEY` header | `list` of `quoteId`, `orderId`, `status` | OK | [Docs](https://developers.binance.com/docs/binance-spot-api-docs/sapi#convert-tradeFlow) |
+This document summarises how the project implements the Binance Convert API and
+highlights notable deviations from the official documentation.
 
-All endpoints were checked against the official Binance Spot API documentation. Only minimal changes were needed: added explicit handling for error `-2015` and provided a wrapper for the `tradeFlow` endpoint.
+## References
+
+| Endpoint | Official documentation |
+| --- | --- |
+| `exchangeInfo` | https://developers.binance.com/docs/binance-spot-api-docs/sapi#convert-exchangeinfo |
+| `getQuote` | https://developers.binance.com/docs/binance-spot-api-docs/sapi#convert-getquote |
+| `acceptQuote` | https://developers.binance.com/docs/binance-spot-api-docs/sapi#convert-acceptquote |
+| `orderStatus` | https://developers.binance.com/docs/binance-spot-api-docs/sapi#convert-orderstatus |
+| `tradeFlow` | https://developers.binance.com/docs/binance-spot-api-docs/sapi#convert-tradeflow |
+
+## Endpoint summary
+
+| Endpoint | Method | Path | Signing | Params (req/opt) | Source | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| exchangeInfo | GET | `/sapi/v1/convert/exchangeInfo` | **None** | `fromAsset?`, `toAsset?` | query | cached for 30 min |
+| getQuote | POST | `/sapi/v1/convert/getQuote` | **SIGNED** | `fromAsset`, `toAsset`, exactly one of `fromAmount`/`toAmount`, `walletType?` | body | returns `validTime` and pricing ratios |
+| acceptQuote | POST | `/sapi/v1/convert/acceptQuote` | **SIGNED** | `quoteId`, `walletType?` | body | returns `orderId` and `createTime` |
+| orderStatus | GET | `/sapi/v1/convert/orderStatus` | **SIGNED** | `orderId` **or** `quoteId` | query | params are mutually exclusive |
+| tradeFlow | GET | `/sapi/v1/convert/tradeFlow` | **SIGNED** | `startTime`, `endTime`, `cursor?`, `limit?` | query | wrapper returns `{list, cursor}` for pagination |
+
+## Error handling and limits
+
+* `-2015` → `PermissionError`
+* `-1021` → `ClockSkewError` (timestamp drift)
+* 418/429/`-1003` → minimal exponential backoff; no specialised throttling
+
+## DRY‑RUN semantics
+
+Local PAPER/DRY-RUN mode intentionally diverges from Binance behaviour:
+
+* `accept_quote` does **not** call Binance and returns `{"dryRun": true, ...}`
+  without `orderId`.
+* Conversions in this mode are logged with `accepted = False` and `dryRun = True`.
+
+## Test status
+
+* Branch: `dev3`, commit `26d64afc7c384a71cfb679f0dbe069e2fd5b17d3`
+* `pytest -q` → 23 passed
+* `PAPER=1 PAPER_BALANCES="USDT=100" python3 daily_analysis.py`
+  produced non-empty `logs/predictions.json`
+* `PAPER=1 PAPER_BALANCES="USDT=100" python3 run_convert_trade.py`
+  produced only dry‑run entries in `logs/convert_history.json`
+

--- a/tests/test_convert_cycle.py
+++ b/tests/test_convert_cycle.py
@@ -1,6 +1,7 @@
 import types
 import os
 import sys
+import types
 
 sys.path.insert(0, os.getcwd())
 
@@ -30,15 +31,16 @@ def test_accept_only_with_orderid(monkeypatch):
 
     records = []
 
-    def fake_log(quote_data, accepted, order_id, error, create_time):
-        records.append({'accepted': accepted, 'orderId': order_id, 'createTime': create_time})
+    def fake_log(quote_data, accepted, order_id, error, create_time, dry_run):
+        records.append({'accepted': accepted, 'orderId': order_id, 'dryRun': dry_run})
 
     monkeypatch.setattr(convert_cycle, 'log_conversion_result', fake_log)
 
-    monkeypatch.setattr(convert_cycle, 'accept_quote', lambda qid: {})
+    monkeypatch.setattr(convert_cycle, 'accept_quote', lambda qid: {'dryRun': True})
     res = convert_cycle.process_pair('USDT', ['BTC'], 1.0, 0.0)
     assert res is False
     assert records[0]['accepted'] is False
+    assert records[0]['dryRun'] is True
 
     records.clear()
     monkeypatch.setattr(convert_cycle, 'accept_quote', lambda qid: {'orderId': '1', 'createTime': 2})


### PR DESCRIPTION
## Summary
- Skip Binance acceptQuote in PAPER/DRY-RUN and flag results with `dryRun`
- Log comprehensive convert fields and respect DRY-RUN flag when determining acceptance
- Document Convert API usage and local deviations

## Testing
- `pytest -q`
- `PAPER=1 PAPER_BALANCES="USDT=100" python3 daily_analysis.py`
- `PAPER=1 PAPER_BALANCES="USDT=100" python3 run_convert_trade.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5c07a176c8329bd93f526ee36037e