### PR TITLE
Load Binance credentials from config file with env fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Telegram Crypto Bot
+
+This project interacts with Binance Convert endpoints. Binance API keys are **not** stored in `.env` files or systemd unit definitions.
+
+## Binance credentials
+
+The only canonical location for Binance keys on the host is `/root/telegram-crypto-bot-github/config_dev3.py` (or a path pointed to by `DEV_CONFIG_PATH`). The file must define:
+
+```python
+BINANCE_API_KEY = "..."
+BINANCE_API_SECRET = "..."
+```
+
+At runtime the application loads these credentials from that file. If the file is missing, it falls back to `BINANCE_API_KEY` and `BINANCE_API_SECRET` environment variables.
+
+For temporary shells you can export the variables without duplicating secrets:
+
+```bash
+export BINANCE_KEY=$(python3 - <<'PY'
+import importlib.util
+p="/root/telegram-crypto-bot-github/config_dev3.py"
+spec=importlib.util.spec_from_file_location("cfg", p)
+m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+print(getattr(m, "BINANCE_API_KEY", ""))
+PY
+)
+
+export BINANCE_SECRET=$(python3 - <<'PY'
+import importlib.util
+p="/root/telegram-crypto-bot-github/config_dev3.py"
+spec=importlib.util.spec_from_file_location("cfg", p)
+m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+print(getattr(m, "BINANCE_API_SECRET", ""))
+PY
+)
+```
+
+Systemd units do not embed secrets; they rely on the above configuration file or explicitly exported environment variables before launch.

--- a/tests/test_convert_api.py
+++ b/tests/test_convert_api.py
@@ -6,12 +6,15 @@ import pytest
 
 sys.path.insert(0, os.getcwd())
 
+os.environ.setdefault("BINANCE_API_KEY", "test")
+os.environ.setdefault("BINANCE_API_SECRET", "test")
+
 import types
 import convert_api
 
 
 def test_sign_deterministic(monkeypatch):
-    monkeypatch.setattr(convert_api, 'BINANCE_SECRET_KEY', 'secret')
+    monkeypatch.setattr(convert_api, 'BINANCE_API_SECRET', 'secret')
     monkeypatch.setattr(convert_api, 'get_current_timestamp', lambda: 1234567890)
     params = {'fromAsset': 'USDT', 'toAsset': 'BTC'}
     signed = convert_api._sign(params.copy())
@@ -57,7 +60,7 @@ def test_request_adds_signature_and_header(monkeypatch):
         return Resp()
 
     monkeypatch.setattr(convert_api, '_session', type('S', (), {'post': fake_post})())
-    monkeypatch.setattr(convert_api, 'BINANCE_SECRET_KEY', 'secret')
+    monkeypatch.setattr(convert_api, 'BINANCE_API_SECRET', 'secret')
     monkeypatch.setattr(convert_api, 'BINANCE_API_KEY', 'key')
     monkeypatch.setattr(convert_api, 'get_current_timestamp', lambda: 1)
 
@@ -272,7 +275,7 @@ def test_get_quote_signed(monkeypatch):
         return R()
 
     monkeypatch.setattr(convert_api, '_session', type('S', (), {'post': fake_post})())
-    monkeypatch.setattr(convert_api, 'BINANCE_SECRET_KEY', 'secret')
+    monkeypatch.setattr(convert_api, 'BINANCE_API_SECRET', 'secret')
     monkeypatch.setattr(convert_api, 'BINANCE_API_KEY', 'key')
     monkeypatch.setattr(convert_api, 'get_current_timestamp', lambda: 1)
     monkeypatch.setattr(convert_api, 'increment_quote_usage', lambda: None)
@@ -308,7 +311,7 @@ def test_accept_quote_live(monkeypatch):
     monkeypatch.setenv('PAPER', '0')
     monkeypatch.setenv('ENABLE_LIVE', '1')
     monkeypatch.setattr(convert_api, '_session', type('S', (), {'post': fake_post})())
-    monkeypatch.setattr(convert_api, 'BINANCE_SECRET_KEY', 'secret')
+    monkeypatch.setattr(convert_api, 'BINANCE_API_SECRET', 'secret')
     monkeypatch.setattr(convert_api, 'BINANCE_API_KEY', 'key')
     monkeypatch.setattr(convert_api, 'get_current_timestamp', lambda: 1)
     convert_api._time_offset_ms = 0
@@ -362,7 +365,7 @@ def test_accept_quote_idempotent(monkeypatch):
 
     sess = Sess()
     monkeypatch.setattr(convert_api, '_session', sess)
-    monkeypatch.setattr(convert_api, 'BINANCE_SECRET_KEY', 'secret')
+    monkeypatch.setattr(convert_api, 'BINANCE_API_SECRET', 'secret')
     monkeypatch.setattr(convert_api, 'BINANCE_API_KEY', 'key')
     monkeypatch.setattr(convert_api, 'get_current_timestamp', lambda: 1)
     convert_api._time_offset_ms = 0
@@ -488,7 +491,7 @@ def test_permission_error(monkeypatch):
 
     monkeypatch.setattr(convert_api, '_session', Sess())
     monkeypatch.setattr(convert_api, 'get_current_timestamp', lambda: 0)
-    monkeypatch.setattr(convert_api, 'BINANCE_SECRET_KEY', 'secret')
+    monkeypatch.setattr(convert_api, 'BINANCE_API_SECRET', 'secret')
     monkeypatch.setattr(convert_api, 'BINANCE_API_KEY', 'key')
 
     with pytest.raises(PermissionError):

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,89 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.getcwd())
+
+
+def _make_cfg(tmp_path: Path, key: str = "file-key", secret: str = "file-secret") -> Path:
+    cfg = tmp_path / "cfg.py"
+    cfg.write_text(
+        f"BINANCE_API_KEY = '{key}'\nBINANCE_API_SECRET = '{secret}'\n",
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def test_loads_from_file(monkeypatch, tmp_path):
+    cfg = _make_cfg(tmp_path)
+    monkeypatch.setenv("DEV_CONFIG_PATH", str(cfg))
+    monkeypatch.delenv("BINANCE_API_KEY", raising=False)
+    monkeypatch.delenv("BINANCE_API_SECRET", raising=False)
+    import convert_api
+    importlib.reload(convert_api)
+    assert convert_api.BINANCE_API_KEY == "file-key"
+    assert convert_api.BINANCE_API_SECRET == "file-secret"
+
+
+def test_loads_from_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("BINANCE_API_KEY", "env-key")
+    monkeypatch.setenv("BINANCE_API_SECRET", "env-secret")
+    monkeypatch.setenv("DEV_CONFIG_PATH", str(tmp_path / "missing.py"))
+    import convert_api
+    importlib.reload(convert_api)
+    assert convert_api.BINANCE_API_KEY == "env-key"
+    assert convert_api.BINANCE_API_SECRET == "env-secret"
+
+
+def test_missing_credentials(monkeypatch, tmp_path):
+    monkeypatch.delenv("BINANCE_API_KEY", raising=False)
+    monkeypatch.delenv("BINANCE_API_SECRET", raising=False)
+    monkeypatch.setenv("DEV_CONFIG_PATH", str(tmp_path / "missing.py"))
+    import convert_api
+    with pytest.raises(RuntimeError):
+        importlib.reload(convert_api)
+
+
+def test_no_keys_in_logs(monkeypatch, caplog):
+    import convert_api
+    monkeypatch.setattr(convert_api, "BINANCE_API_KEY", "AKID1234")
+    monkeypatch.setattr(convert_api, "BINANCE_API_SECRET", "SKID5678")
+    monkeypatch.setattr(convert_api, "_time_synced", True)
+
+    class Sess:
+        def __init__(self):
+            self.calls = 0
+
+        def post(self, url, data=None, headers=None, timeout=None, params=None):
+            self.calls += 1
+
+            class R:
+                status_code = 200
+                headers = {}
+
+                def json(inner_self):
+                    if self.calls == 1:
+                        return {"code": -1003, "msg": "oops"}
+                    return {}
+
+            return R()
+
+    sess = Sess()
+    monkeypatch.setattr(convert_api, "_session", sess)
+    monkeypatch.setattr(
+        convert_api,
+        "time",
+        type("T", (), {"sleep": lambda s: None, "time": lambda: 0}),
+    )
+    monkeypatch.setattr(convert_api, "random", type("R", (), {"uniform": lambda a, b: 0}))
+    monkeypatch.setattr(convert_api, "get_current_timestamp", lambda: 0)
+
+    with caplog.at_level("WARNING"):
+        convert_api._request("POST", "/sapi/v1/convert/getQuote", {"a": 1})
+
+    assert "AKID1234" not in caplog.text
+    assert "SKID5678" not in caplog.text
+


### PR DESCRIPTION
## Summary
- centralize Binance API key loading in `load_binance_credentials()` with fallback to env
- document single-source secret policy in README
- add tests for credential loading and absence of key leakage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba8dcd4f7883298d0a63295cfdc940