### PR TITLE
feat: add preflight filters and retry logic

### DIFF
--- a/convert_api.py
+++ b/convert_api.py
@@ -170,13 +170,11 @@ def _request(method: str, path: str, params: Dict[str, Any], *, signed: bool = T
             if code is not None:
                 logger.warning("Binance error %s: %s", code, data.get("msg"))
             if code == -1021:
+                time.sleep(_backoff(attempt))
                 if not tried_time_sync:
                     tried_time_sync = True
                     _sync_time()
-                    continue
-                raise ClockSkewError(
-                    "Binance timestamp rejected (possible clock skew). Adjust time or increase recvWindow.",
-                )
+                continue
             if code == -1022:
                 raise ValueError("Signature for this request is not valid")
             if code in (-1102, -1103):

--- a/convert_logger.py
+++ b/convert_logger.py
@@ -116,6 +116,11 @@ def log_conversion_result(
     mode: str | None = None,
     edge: float | None = None,
     region: str | None = None,
+    step_size: str | None = None,
+    min_notional: str | None = None,
+    px: str | None = None,
+    est_notional: str | None = None,
+    reason: str | None = None,
 ) -> None:
     """Log conversion result to history using the new unified schema."""
 
@@ -144,14 +149,24 @@ def log_conversion_result(
         "dryRun": dry_run,
         "edge": edge,
         "mode": mode,
+        "stepSize": step_size,
+        "minNotional": min_notional,
+        "px": px,
+        "estNotional": est_notional,
+        "reason": reason,
     }
 
     logger.info(
-        "[dev3] quoteId=%s -> accept %s -> orderId=%s -> status=%s",
+        "[dev3] quoteId=%s -> accept %s -> orderId=%s -> status=%s stepSize=%s minNotional=%s px=%s est=%s reason=%s",
         entry["quoteId"],
         "\u2705" if accepted else "\u274c",
         order_id,
         status,
+        step_size,
+        min_notional,
+        px,
+        est_notional,
+        reason,
     )
 
     log_convert_history(entry)

--- a/exchange_filters.py
+++ b/exchange_filters.py
@@ -1,0 +1,46 @@
+from decimal import Decimal
+import requests
+
+
+def load_symbol_filters(base_asset: str, quote_asset: str = "USDT"):
+    """Return LOT_SIZE.stepSize and MIN_NOTIONAL.minNotional for a symbol.
+
+    If the pair does not exist, returns ``(None, None)`` and logs should warn.
+    """
+    try:
+        resp = requests.get(
+            "https://api.binance.com/api/v3/exchangeInfo", timeout=10
+        )
+        data = resp.json()
+    except Exception:  # pragma: no cover - network/IO
+        return None, None
+
+    for s in data.get("symbols", []):
+        if s.get("baseAsset") == base_asset and s.get("quoteAsset") == quote_asset:
+            step = Decimal("0")
+            min_n = Decimal("0")
+            for f in s.get("filters", []):
+                if f.get("filterType") == "LOT_SIZE":
+                    step = Decimal(str(f.get("stepSize", "0")))
+                elif f.get("filterType") == "MIN_NOTIONAL":
+                    min_n = Decimal(str(f.get("minNotional", "0")))
+            return step, min_n
+    return None, None
+
+
+def get_last_price_usdt(asset: str):
+    """Return last price of ASSETUSDT pair as Decimal or ``None`` if missing."""
+    try:
+        r = requests.get(
+            "https://api.binance.com/api/v3/ticker/price",
+            params={"symbol": f"{asset}USDT"},
+            timeout=10,
+        )
+    except Exception:  # pragma: no cover - network/IO
+        return None
+    if r.status_code == 200:
+        try:
+            return Decimal(r.json()["price"])
+        except Exception:  # pragma: no cover
+            return None
+    return None

--- a/tests/test_convert_cycle.py
+++ b/tests/test_convert_cycle.py
@@ -32,7 +32,23 @@ def test_accept_only_with_orderid(monkeypatch):
 
     records = []
 
-    def fake_log(quote_data, accepted, order_id, error, create_time, dry_run, order_status=None, mode=None, edge=None, region=None):
+    def fake_log(
+        quote_data,
+        accepted,
+        order_id,
+        error,
+        create_time,
+        dry_run,
+        order_status=None,
+        mode=None,
+        edge=None,
+        region=None,
+        step_size=None,
+        min_notional=None,
+        px=None,
+        est_notional=None,
+        reason=None,
+    ):
         records.append({'accepted': accepted, 'orderId': order_id, 'dryRun': dry_run})
 
     monkeypatch.setattr(convert_cycle, 'log_conversion_result', fake_log)
@@ -87,7 +103,23 @@ def test_not_accepted_without_success(monkeypatch):
 
     records = []
 
-    def fake_log(quote_data, accepted, order_id, error, create_time, dry_run, order_status=None, mode=None, edge=None, region=None):
+    def fake_log(
+        quote_data,
+        accepted,
+        order_id,
+        error,
+        create_time,
+        dry_run,
+        order_status=None,
+        mode=None,
+        edge=None,
+        region=None,
+        step_size=None,
+        min_notional=None,
+        px=None,
+        est_notional=None,
+        reason=None,
+    ):
         records.append({'accepted': accepted, 'orderId': order_id})
 
     monkeypatch.setattr(convert_cycle, 'log_conversion_result', fake_log)

--- a/tests/test_filters_rounding_min_notional.py
+++ b/tests/test_filters_rounding_min_notional.py
@@ -1,0 +1,99 @@
+import sys
+import os
+import types
+
+os.environ.setdefault("BINANCE_API_KEY", "k")
+os.environ.setdefault("BINANCE_API_SECRET", "s")
+sys.modules.setdefault(
+    "config_dev3", types.SimpleNamespace(TELEGRAM_CHAT_ID="", TELEGRAM_TOKEN="")
+)
+
+sys.path.insert(0, os.getcwd())
+
+import convert_cycle
+import exchange_filters
+
+
+def setup_env(monkeypatch):
+    monkeypatch.setenv("PAPER", "1")
+    monkeypatch.setenv("ENABLE_LIVE", "0")
+
+
+def test_filters_rounding_and_min_notional(monkeypatch):
+    setup_env(monkeypatch)
+
+    def fake_get(url, params=None, timeout=10):
+        class Resp:
+            status_code = 200
+
+            def __init__(self, data):
+                self._data = data
+
+            def json(self):
+                return self._data
+
+        if "exchangeInfo" in url:
+            data = {
+                "symbols": [
+                    {
+                        "baseAsset": "AAA",
+                        "quoteAsset": "USDT",
+                        "filters": [
+                            {"filterType": "LOT_SIZE", "stepSize": "0.01"},
+                            {"filterType": "MIN_NOTIONAL", "minNotional": "10"},
+                        ],
+                    }
+                ]
+            }
+            return Resp(data)
+        data = {"price": "2.5"}
+        return Resp(data)
+
+    monkeypatch.setattr(exchange_filters, "requests", types.SimpleNamespace(get=fake_get))
+
+    calls = {"get_quote": 0, "amounts": []}
+
+    def fake_get_quote(frm, to, amt):
+        calls["get_quote"] += 1
+        calls["amounts"].append(amt)
+        return {
+            "quoteId": "1",
+            "ratio": 1.0,
+            "inverseRatio": 1.0,
+            "fromAmount": amt,
+            "toAmount": amt,
+            "score": 1.0,
+        }
+
+    monkeypatch.setattr(convert_cycle, "get_quote", fake_get_quote)
+    monkeypatch.setattr(convert_cycle, "reset_cycle", lambda: None)
+    monkeypatch.setattr(convert_cycle, "should_throttle", lambda *a, **k: False)
+    monkeypatch.setattr(
+        convert_cycle, "filter_top_tokens", lambda tokens, score_threshold, top_n=2: list(tokens.items())
+    )
+
+    records = []
+
+    def fake_log(quote, accepted, order_id, error, create_time, dry_run, order_status, mode, edge, region, step_size, min_notional, px, est_notional, reason):
+        records.append(
+            {
+                "fromAmount": quote.get("fromAmount"),
+                "reason": reason,
+                "step": step_size,
+                "px": px,
+                "est": est_notional,
+            }
+        )
+
+    monkeypatch.setattr(convert_cycle, "log_conversion_result", fake_log)
+
+    convert_cycle.process_pair("AAA", ["BBB"], 3.999, 0.0)
+    assert calls["get_quote"] == 0
+    assert records and records[0]["reason"] == "skip(minNotional)"
+    assert records[0]["fromAmount"] == "3.99"
+
+    records.clear()
+    calls["get_quote"] = 0
+    convert_cycle.process_pair("AAA", ["BBB"], 4.01, 0.0)
+    assert calls["get_quote"] == 1
+    assert calls["amounts"][0] == 4.01

--- a/tests/test_quote_validity_and_final_status.py
+++ b/tests/test_quote_validity_and_final_status.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import types
+
+os.environ.setdefault("BINANCE_API_KEY", "k")
+os.environ.setdefault("BINANCE_API_SECRET", "s")
+sys.modules.setdefault(
+    "config_dev3", types.SimpleNamespace(TELEGRAM_CHAT_ID="", TELEGRAM_TOKEN="")
+)
+
+sys.path.insert(0, os.getcwd())
+
+import convert_cycle
+import convert_api
+
+
+def setup_env(monkeypatch):
+    monkeypatch.setenv("PAPER", "1")
+    monkeypatch.setenv("ENABLE_LIVE", "0")
+
+
+def test_expired_quote_skipped(monkeypatch):
+    setup_env(monkeypatch)
+    monkeypatch.setattr(convert_cycle, "reset_cycle", lambda: None)
+    monkeypatch.setattr(convert_cycle, "should_throttle", lambda *a, **k: False)
+    monkeypatch.setattr(convert_cycle, "load_symbol_filters", lambda *a, **k: (None, None))
+    monkeypatch.setattr(convert_cycle, "get_last_price_usdt", lambda *a, **k: None)
+    monkeypatch.setattr(
+        convert_cycle, "filter_top_tokens", lambda tokens, score_threshold, top_n=2: list(tokens.items())
+    )
+    current = 1000
+    monkeypatch.setattr(convert_api, "_current_timestamp", lambda: current)
+    quote = {
+        "quoteId": "q1",
+        "ratio": 1.0,
+        "inverseRatio": 1.0,
+        "fromAmount": 1.0,
+        "toAmount": 1.0,
+        "score": 1.0,
+        "validTimestamp": current - 1,
+    }
+    monkeypatch.setattr(convert_cycle, "get_quote", lambda *a, **k: quote)
+    calls = {"accept": 0}
+    monkeypatch.setattr(convert_cycle, "accept_quote", lambda qid: calls.__setitem__("accept", calls["accept"] + 1))
+    monkeypatch.setattr(convert_cycle, "log_conversion_result", lambda *a, **k: None)
+    res = convert_cycle.process_pair("USDT", ["BTC"], 1.0, 0.0)
+    assert res is False
+    assert calls["accept"] == 0
+
+
+def test_only_success_recorded(monkeypatch):
+    monkeypatch.setenv("PAPER", "0")
+    monkeypatch.setenv("ENABLE_LIVE", "1")
+    monkeypatch.setattr(convert_cycle, "reset_cycle", lambda: None)
+    monkeypatch.setattr(convert_cycle, "should_throttle", lambda *a, **k: False)
+    monkeypatch.setattr(convert_cycle, "load_symbol_filters", lambda *a, **k: (None, None))
+    monkeypatch.setattr(convert_cycle, "get_last_price_usdt", lambda *a, **k: None)
+    monkeypatch.setattr(
+        convert_cycle, "filter_top_tokens", lambda tokens, score_threshold, top_n=2: list(tokens.items())
+    )
+    monkeypatch.setattr(convert_api, "_current_timestamp", lambda: 1000)
+    quote = {
+        "quoteId": "q2",
+        "ratio": 1.0,
+        "inverseRatio": 1.0,
+        "fromAmount": 1.0,
+        "toAmount": 1.0,
+        "score": 1.0,
+        "validTimestamp": 2000,
+    }
+    monkeypatch.setattr(convert_cycle, "get_quote", lambda *a, **k: quote)
+    monkeypatch.setattr(convert_cycle, "log_conversion_result", lambda *a, **k: None)
+    monkeypatch.setattr(convert_cycle, "accept_quote", lambda qid: {"orderId": "1", "createTime": 2})
+    monkeypatch.setattr(convert_cycle, "get_order_status", lambda **k: {"orderStatus": "FAIL"})
+    res = convert_cycle.process_pair("USDT", ["BTC"], 1.0, 0.0)
+    assert res is False
+
+    monkeypatch.setattr(convert_cycle, "get_order_status", lambda **k: {"orderStatus": "SUCCESS"})
+    res = convert_cycle.process_pair("USDT", ["BTC"], 1.0, 0.0)
+    assert res is True

--- a/tests/test_recv_window_and_-1021_retry.py
+++ b/tests/test_recv_window_and_-1021_retry.py
@@ -1,0 +1,71 @@
+import sys
+import os
+import types
+
+os.environ.setdefault("BINANCE_API_KEY", "k")
+os.environ.setdefault("BINANCE_API_SECRET", "s")
+sys.modules.setdefault(
+    "config_dev3", types.SimpleNamespace(TELEGRAM_CHAT_ID="", TELEGRAM_TOKEN="")
+)
+
+sys.path.insert(0, os.getcwd())
+
+import convert_api
+
+
+class Resp:
+    status_code = 200
+
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+def test_recv_window_and_retry(monkeypatch):
+    sent = []
+
+    def record_post(url, data=None, headers=None, timeout=10):
+        sent.append(data)
+        return Resp({})
+
+    def record_get(url, params=None, headers=None, timeout=10):
+        sent.append(params)
+        if "tradeFlow" in url:
+            return Resp({"list": []})
+        return Resp({"orderStatus": "SUCCESS"})
+
+    monkeypatch.setattr(convert_api._session, "post", record_post)
+    monkeypatch.setattr(convert_api._session, "get", record_get)
+    convert_api._time_synced = True
+
+    convert_api.get_quote_with_id("A", "B", from_amount=1.0)
+    convert_api.accept_quote("qid")
+    convert_api.get_order_status(orderId="1")
+    convert_api.trade_flow(startTime=1, endTime=2)
+
+    for p in sent:
+        assert p["recvWindow"] == convert_api.DEFAULT_RECV_WINDOW
+        assert "timestamp" in p
+
+    calls = {"n": 0}
+    sync_calls = []
+    sleeps = []
+
+    def fake_get(url, params=None, headers=None, timeout=10):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return Resp({"code": -1021, "msg": "clock"})
+        return Resp({"orderStatus": "SUCCESS"})
+
+    monkeypatch.setattr(convert_api._session, "get", fake_get)
+    monkeypatch.setattr(convert_api, "_sync_time", lambda: sync_calls.append(1))
+    monkeypatch.setattr(convert_api.time, "sleep", lambda s: sleeps.append(s))
+    convert_api._time_synced = True
+
+    convert_api.get_order_status(orderId="1")
+
+    assert calls["n"] == 2
+    assert len(sync_calls) == 1
+    assert sleeps and sleeps[0] > 0

--- a/tests/test_tradeflow_reconcile.py
+++ b/tests/test_tradeflow_reconcile.py
@@ -1,0 +1,51 @@
+import json
+import sys
+import os
+import types
+
+os.environ.setdefault("BINANCE_API_KEY", "k")
+os.environ.setdefault("BINANCE_API_SECRET", "s")
+sys.modules.setdefault(
+    "config_dev3", types.SimpleNamespace(TELEGRAM_CHAT_ID="", TELEGRAM_TOKEN="")
+)
+
+sys.path.insert(0, os.getcwd())
+
+import convert_api
+import trade_history_sync
+
+
+def test_tradeflow_reconcile(monkeypatch, tmp_path):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    with open(logs / "convert_history.json", "w") as f:
+        json.dump([{ "quoteId": "old" }], f)
+
+    monkeypatch.setattr(convert_api, "_current_timestamp", lambda: 1000)
+
+    def fake_trade_flow(startTime, endTime):
+        return {
+            "list": [
+                {"quoteId": "old"},
+                {
+                    "quoteId": "new",
+                    "fromAsset": "A",
+                    "toAsset": "B",
+                    "fromAmount": "1",
+                    "toAmount": "2",
+                    "status": "SUCCESS",
+                    "orderId": "1",
+                    "createTime": 5,
+                },
+            ]
+        }
+
+    monkeypatch.setattr(convert_api, "trade_flow", fake_trade_flow)
+
+    records = []
+    monkeypatch.setattr(trade_history_sync, "log_conversion_result", lambda *a, **k: records.append(a[0]))
+    monkeypatch.chdir(tmp_path)
+
+    added = trade_history_sync.sync_recent_trades(minutes=1)
+    assert added == 1
+    assert records and records[0]["quoteId"] == "new"


### PR DESCRIPTION
## Summary
- validate Convert amounts against Binance LOT_SIZE and MIN_NOTIONAL filters
- ensure signed requests include recvWindow and retry on -1021 clock skew
- record pre-flight data and reasons in conversion history

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bab21b8060832995482b427bbd5227