### PR TITLE
feat: add systemd timers for convert sessions

### DIFF
--- a/systemd/balance_guard.service
+++ b/systemd/balance_guard.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run balance guard
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/crypto-bot
+ExecStart=/usr/bin/python3 /opt/crypto-bot/balance_guard.py
+Restart=no
+ExecStopPost=/bin/sleep 1
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/balance_guard.timer
+++ b/systemd/balance_guard.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Schedule balance guard check
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+Unit=balance_guard.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/convert_america.service
+++ b/systemd/convert_america.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run convert trade cycle (america session)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/crypto-bot
+ExecStart=/usr/bin/python3 /opt/crypto-bot/run_convert_trade.py --session america
+Restart=no
+ExecStopPost=/bin/sleep 1
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/convert_america.timer
+++ b/systemd/convert_america.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Schedule convert trade cycle (america session)
+
+[Timer]
+OnCalendar=*-*-* 17:15
+Persistent=true
+Unit=convert_america.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/convert_asia.service
+++ b/systemd/convert_asia.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run convert trade cycle (asia session)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/crypto-bot
+ExecStart=/usr/bin/python3 /opt/crypto-bot/run_convert_trade.py --session asia
+Restart=no
+ExecStopPost=/bin/sleep 1
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/convert_asia.timer
+++ b/systemd/convert_asia.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Schedule convert trade cycle (asia session)
+
+[Timer]
+OnCalendar=*-*-* 05:45
+Persistent=true
+Unit=convert_asia.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/gpt_convert_america.service
+++ b/systemd/gpt_convert_america.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Daily analysis for convert (america session)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/crypto-bot
+ExecStart=/usr/bin/python3 /opt/crypto-bot/daily_analysis.py --mode convert --session america
+Restart=no
+ExecStopPost=/bin/sleep 1
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/gpt_convert_america.timer
+++ b/systemd/gpt_convert_america.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Schedule daily analysis for convert (america session)
+
+[Timer]
+OnCalendar=*-*-* 16:15
+Persistent=true
+Unit=gpt_convert_america.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/gpt_convert_asia.service
+++ b/systemd/gpt_convert_asia.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Daily analysis for convert (asia session)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/crypto-bot
+ExecStart=/usr/bin/python3 /opt/crypto-bot/daily_analysis.py --mode convert --session asia
+Restart=no
+ExecStopPost=/bin/sleep 1
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/gpt_convert_asia.timer
+++ b/systemd/gpt_convert_asia.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Schedule daily analysis for convert (asia session)
+
+[Timer]
+OnCalendar=*-*-* 04:45
+Persistent=true
+Unit=gpt_convert_asia.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add systemd services and timers for daily analysis in asia/america sessions
- schedule convert trading cycles for asia and america
- run balance guard every five minutes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68bd2823cfb083299df94068c5bea09e