### PR TITLE
refactor: load credentials from config file

### DIFF
--- a/convert_notifier.py
+++ b/convert_notifier.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional
 
 import requests
-from config_dev3 import TELEGRAM_CHAT_ID, TELEGRAM_TOKEN
+from config_dev3 import BINANCE_API_KEY, BINANCE_API_SECRET, OPENAI_API_KEY, TELEGRAM_TOKEN, CHAT_ID
 
 
 _current_from_token: Optional[str] = None
@@ -37,12 +37,12 @@ atexit.register(flush_failures)
 
 
 def _send(text: str) -> None:
-    if not TELEGRAM_TOKEN or not TELEGRAM_CHAT_ID:
+    if not TELEGRAM_TOKEN or not CHAT_ID:
         return
     try:
         requests.post(
             f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage",
-            json={"chat_id": TELEGRAM_CHAT_ID, "text": text},
+            json={"chat_id": CHAT_ID, "text": text},
             timeout=10,
         )
     except Exception:

--- a/tests/test_convert_api.py
+++ b/tests/test_convert_api.py
@@ -2,14 +2,22 @@ import hmac
 import hashlib
 import os
 import sys
+import types
 import pytest
 
 sys.path.insert(0, os.getcwd())
 
-os.environ.setdefault("BINANCE_API_KEY", "test")
-os.environ.setdefault("BINANCE_API_SECRET", "test")
+sys.modules.setdefault(
+    "config_dev3",
+    types.SimpleNamespace(
+        BINANCE_API_KEY="k",
+        BINANCE_API_SECRET="s",
+        OPENAI_API_KEY="",
+        TELEGRAM_TOKEN="",
+        CHAT_ID="",
+    ),
+)
 
-import types
 import convert_api
 
 

--- a/tests/test_convert_cycle.py
+++ b/tests/test_convert_cycle.py
@@ -5,7 +5,16 @@ import types
 
 sys.path.insert(0, os.getcwd())
 
-sys.modules.setdefault('config_dev3', types.SimpleNamespace(TELEGRAM_CHAT_ID='', TELEGRAM_TOKEN=''))
+sys.modules.setdefault(
+    'config_dev3',
+    types.SimpleNamespace(
+        BINANCE_API_KEY='k',
+        BINANCE_API_SECRET='s',
+        OPENAI_API_KEY='',
+        TELEGRAM_TOKEN='',
+        CHAT_ID='',
+    ),
+)
 import convert_cycle
 import convert_api
 

--- a/tests/test_filters_rounding_min_notional.py
+++ b/tests/test_filters_rounding_min_notional.py
@@ -2,10 +2,15 @@ import sys
 import os
 import types
 
-os.environ.setdefault("BINANCE_API_KEY", "k")
-os.environ.setdefault("BINANCE_API_SECRET", "s")
 sys.modules.setdefault(
-    "config_dev3", types.SimpleNamespace(TELEGRAM_CHAT_ID="", TELEGRAM_TOKEN="")
+    "config_dev3",
+    types.SimpleNamespace(
+        BINANCE_API_KEY="k",
+        BINANCE_API_SECRET="s",
+        OPENAI_API_KEY="",
+        TELEGRAM_TOKEN="",
+        CHAT_ID="",
+    ),
 )
 
 sys.path.insert(0, os.getcwd())

--- a/tests/test_quote_validity_and_final_status.py
+++ b/tests/test_quote_validity_and_final_status.py
@@ -2,10 +2,15 @@ import os
 import sys
 import types
 
-os.environ.setdefault("BINANCE_API_KEY", "k")
-os.environ.setdefault("BINANCE_API_SECRET", "s")
 sys.modules.setdefault(
-    "config_dev3", types.SimpleNamespace(TELEGRAM_CHAT_ID="", TELEGRAM_TOKEN="")
+    "config_dev3",
+    types.SimpleNamespace(
+        BINANCE_API_KEY="k",
+        BINANCE_API_SECRET="s",
+        OPENAI_API_KEY="",
+        TELEGRAM_TOKEN="",
+        CHAT_ID="",
+    ),
 )
 
 sys.path.insert(0, os.getcwd())

--- a/tests/test_recv_window_and_-1021_retry.py
+++ b/tests/test_recv_window_and_-1021_retry.py
@@ -2,10 +2,15 @@ import sys
 import os
 import types
 
-os.environ.setdefault("BINANCE_API_KEY", "k")
-os.environ.setdefault("BINANCE_API_SECRET", "s")
 sys.modules.setdefault(
-    "config_dev3", types.SimpleNamespace(TELEGRAM_CHAT_ID="", TELEGRAM_TOKEN="")
+    "config_dev3",
+    types.SimpleNamespace(
+        BINANCE_API_KEY="k",
+        BINANCE_API_SECRET="s",
+        OPENAI_API_KEY="",
+        TELEGRAM_TOKEN="",
+        CHAT_ID="",
+    ),
 )
 
 sys.path.insert(0, os.getcwd())

--- a/tests/test_tradeflow_reconcile.py
+++ b/tests/test_tradeflow_reconcile.py
@@ -3,10 +3,15 @@ import sys
 import os
 import types
 
-os.environ.setdefault("BINANCE_API_KEY", "k")
-os.environ.setdefault("BINANCE_API_SECRET", "s")
 sys.modules.setdefault(
-    "config_dev3", types.SimpleNamespace(TELEGRAM_CHAT_ID="", TELEGRAM_TOKEN="")
+    "config_dev3",
+    types.SimpleNamespace(
+        BINANCE_API_KEY="k",
+        BINANCE_API_SECRET="s",
+        OPENAI_API_KEY="",
+        TELEGRAM_TOKEN="",
+        CHAT_ID="",
+    ),
 )
 
 sys.path.insert(0, os.getcwd())


### PR DESCRIPTION
## Summary
- use config_dev3 for Binance API credentials
- switch Telegram notifier to config-based CHAT_ID
- adjust tests to rely on config_dev3 module

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd229f10fc8329a120f55c93a30dba