### PR TITLE
Implement weight budget, mid-price scoring, and risk-off controls

### DIFF
--- a/AUDIT_DEV3.md
+++ b/AUDIT_DEV3.md
@@ -53,11 +53,11 @@ Convert requests add `recvWindow`, `timestamp`, and HMAC‑SHA256 signatures via
 
 ## 7. Weight Budget & Anti‑spam
 
-Quote requests increment daily and per‑cycle counters in `quote_counter` (`QUOTE_LIMIT=950`, `MAX_PER_CYCLE=20`) and throttle when limits are hit【F:quote_counter.py†L9-L107】.
+Quote requests increment daily and per‑cycle counters in `quote_counter` (`QUOTE_LIMIT=950`, `MAX_PER_CYCLE` adjustable). Official weights are encoded for Convert and Market Data endpoints (`getQuote` 200, `acceptQuote` 500, `orderStatus` 100, `avgPrice`/`bookTicker` 2, etc.), tracking total weight per cycle and logging summaries【F:quote_counter.py†L1-L107】【F:convert_cycle.py†L358-L373】.
 
 ## 8. Risk‑off & Logging
 
-`convert_logger.log_conversion_result` records quote ID, ratio, validUntil, acceptance status, latency placeholders, edge score and counters【F:convert_logger.py†L110-L170】. `convert_notifier.flush_failures` aggregates per‑cycle Telegram notifications into a single message【F:convert_notifier.py†L13-L33】. Explicit risk‑off behaviour for >10% drawdown tied to market data was not detected.
+`convert_logger.log_conversion_result` records quote ID, ratio, validUntil, acceptance status, latency placeholders, edge score and counters【F:convert_logger.py†L110-L170】. `convert_notifier.flush_failures` aggregates per‑cycle Telegram notifications into a single message【F:convert_notifier.py†L13-L33】. `risk_off.check_risk` evaluates portfolio drawdown via public market data and lowers cycle limits or pauses trading when drawdown exceeds thresholds【F:risk_off.py†L1-L74】【F:convert_cycle.py†L33-L51】.
 
 ## 9. Secrets & Config
 
@@ -68,8 +68,6 @@ No `.env` files were found in the repository (`find . -name '*.env'`).
 ## 10. Gaps
 
 Gaps:
-- No explicit risk-off for >10% drawdown (must use public Spot Market Data).
-- No mid-price (`avgPrice`/`bookTicker`) in scoring model; required by DEV3 logic.
 - `os.getenv` usage contradicts single-source `config_dev3.py`.
 - Ensure analytics via `data-api.binance.vision`; no Spot trading endpoints present.
 

--- a/market_data.py
+++ b/market_data.py
@@ -1,0 +1,41 @@
+import requests
+from quote_counter import record_weight
+
+BASE_URL = "https://data-api.binance.vision"
+
+
+def _get(path: str, params: dict) -> dict | None:
+    try:
+        resp = requests.get(f"{BASE_URL}{path}", params=params, timeout=10)
+    except Exception:
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        return resp.json()
+    except Exception:
+        return None
+
+
+def get_mid_price(from_asset: str, to_asset: str) -> float | None:
+    symbol = f"{from_asset}{to_asset}"
+    record_weight("bookTicker")
+    data = _get("/api/v3/ticker/bookTicker", {"symbol": symbol})
+    if data:
+        try:
+            bid = float(data.get("bidPrice", 0))
+            ask = float(data.get("askPrice", 0))
+            if bid > 0 and ask > 0:
+                return (bid + ask) / 2
+        except Exception:
+            pass
+    record_weight("avgPrice")
+    data = _get("/api/v3/avgPrice", {"symbol": symbol})
+    if data:
+        try:
+            price = float(data.get("price", 0))
+            if price > 0:
+                return price
+        except Exception:
+            pass
+    return None

--- a/risk_off.py
+++ b/risk_off.py
@@ -1,0 +1,79 @@
+import json
+import os
+from typing import Tuple
+
+import requests
+
+from convert_api import get_balances
+from quote_counter import record_weight
+
+BASE_URL = "https://data-api.binance.vision"
+HIGH_FILE = os.path.join("logs", "portfolio_high.json")
+DRAWDOWN_THRESHOLD = 0.10
+PAUSE_THRESHOLD = 0.25
+
+
+def _load_high() -> float:
+    if os.path.exists(HIGH_FILE):
+        try:
+            with open(HIGH_FILE, "r", encoding="utf-8") as f:
+                return float(json.load(f).get("high", 0))
+        except Exception:
+            return 0.0
+    return 0.0
+
+
+def _save_high(v: float) -> None:
+    os.makedirs(os.path.dirname(HIGH_FILE), exist_ok=True)
+    with open(HIGH_FILE, "w", encoding="utf-8") as f:
+        json.dump({"high": v}, f)
+
+
+def _price_usdt(asset: str) -> float:
+    if asset == "USDT":
+        return 1.0
+    symbol = f"{asset}USDT"
+    record_weight("avgPrice")
+    try:
+        r = requests.get(f"{BASE_URL}/api/v3/avgPrice", params={"symbol": symbol}, timeout=10)
+        if r.status_code == 200:
+            return float(r.json().get("price", 0))
+    except Exception:
+        pass
+    record_weight("ticker24hr")
+    try:
+        r = requests.get(f"{BASE_URL}/api/v3/ticker/24hr", params={"symbol": symbol}, timeout=10)
+        if r.status_code == 200:
+            return float(r.json().get("lastPrice", 0))
+    except Exception:
+        pass
+    return 0.0
+
+
+def portfolio_value() -> float:
+    try:
+        balances = get_balances()
+    except Exception:
+        return 0.0
+    total = 0.0
+    for asset, amount in balances.items():
+        px = _price_usdt(asset)
+        total += amount * px
+    return total
+
+
+def check_risk() -> Tuple[int, float]:
+    """Return (risk_level, drawdown)."""
+    current = portfolio_value()
+    if current <= 0:
+        return 0, 0.0
+    high = _load_high()
+    if current > high:
+        _save_high(current)
+        high = current
+    drawdown = (high - current) / high if high else 0.0
+    if drawdown >= PAUSE_THRESHOLD:
+        return 2, drawdown
+    if drawdown >= DRAWDOWN_THRESHOLD:
+        return 1, drawdown
+    return 0, drawdown

--- a/tests/test_convert_cycle.py
+++ b/tests/test_convert_cycle.py
@@ -25,6 +25,10 @@ import convert_api
 def setup_env(monkeypatch):
     monkeypatch.setattr('config_dev3.DEV3_PAPER_MODE', True)
     monkeypatch.setattr(convert_cycle.config_dev3, 'DEV3_PAPER_MODE', True)
+    monkeypatch.setattr(convert_cycle, 'check_risk', lambda: (0, 0))
+    monkeypatch.setattr(convert_cycle, 'get_mid_price', lambda *a, **k: 1.0)
+    monkeypatch.setattr(convert_cycle, 'log_cycle_summary', lambda: None)
+    monkeypatch.setattr(convert_cycle, 'set_cycle_limit', lambda limit: None)
 
 
 def test_accept_only_with_orderid(monkeypatch):
@@ -98,6 +102,7 @@ def test_accept_only_with_orderid(monkeypatch):
 
 
 def test_not_accepted_without_success(monkeypatch):
+    setup_env(monkeypatch)
     monkeypatch.setattr('config_dev3.DEV3_PAPER_MODE', False)
     monkeypatch.setattr(convert_cycle.config_dev3, 'DEV3_PAPER_MODE', False)
     quote = {

--- a/tests/test_filters_rounding_min_notional.py
+++ b/tests/test_filters_rounding_min_notional.py
@@ -24,6 +24,10 @@ import exchange_filters
 
 def setup_env(monkeypatch):
     monkeypatch.setattr("config_dev3.DEV3_PAPER_MODE", True)
+    monkeypatch.setattr(convert_cycle, "check_risk", lambda: (0, 0))
+    monkeypatch.setattr(convert_cycle, "get_mid_price", lambda *a, **k: 1.0)
+    monkeypatch.setattr(convert_cycle, "log_cycle_summary", lambda: None)
+    monkeypatch.setattr(convert_cycle, "set_cycle_limit", lambda limit: None)
 
 
 def test_filters_rounding_and_min_notional(monkeypatch):
@@ -60,7 +64,7 @@ def test_filters_rounding_and_min_notional(monkeypatch):
 
     calls = {"get_quote": 0, "amounts": []}
 
-    def fake_get_quote(frm, to, amt):
+    def fake_get_quote(frm, to, amt, **kwargs):
         calls["get_quote"] += 1
         calls["amounts"].append(amt)
         return {

--- a/tests/test_quote_validity_and_final_status.py
+++ b/tests/test_quote_validity_and_final_status.py
@@ -25,6 +25,10 @@ import convert_api
 def setup_env(monkeypatch):
     monkeypatch.setattr("config_dev3.DEV3_PAPER_MODE", True)
     monkeypatch.setattr(convert_cycle.config_dev3, "DEV3_PAPER_MODE", True)
+    monkeypatch.setattr(convert_cycle, "check_risk", lambda: (0, 0))
+    monkeypatch.setattr(convert_cycle, "get_mid_price", lambda *a, **k: 1.0)
+    monkeypatch.setattr(convert_cycle, "log_cycle_summary", lambda: None)
+    monkeypatch.setattr(convert_cycle, "set_cycle_limit", lambda limit: None)
 
 
 def test_expired_quote_skipped(monkeypatch):
@@ -57,6 +61,7 @@ def test_expired_quote_skipped(monkeypatch):
 
 
 def test_only_success_recorded(monkeypatch):
+    setup_env(monkeypatch)
     monkeypatch.setattr("config_dev3.DEV3_PAPER_MODE", False)
     monkeypatch.setattr(convert_cycle.config_dev3, "DEV3_PAPER_MODE", False)
     monkeypatch.setattr(convert_cycle, "reset_cycle", lambda: None)


### PR DESCRIPTION
## Summary
- track official Binance weights for Convert and market data endpoints with per-cycle logging
- score convert pairs using mid-price from public avgPrice/bookTicker endpoints
- add risk-off mode that reduces activity or pauses when portfolio drawdown exceeds thresholds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd3ded99808329938fdf6bb3946322