### PR TITLE
Add advanced market data analytics and scoring pipeline

### DIFF
--- a/AUDIT_DEV3.md
+++ b/AUDIT_DEV3.md
@@ -11,7 +11,11 @@
 | `convert_api.exchange_info` | `/sapi/v1/convert/exchangeInfo` | GET | `fromAsset?` | 3000 IP | [Convert Market Data][3] | PASS |
 | `convert_api.asset_info` | `/sapi/v1/convert/assetInfo` | GET | `asset` | 100 IP | [Asset Precision][8] | PASS |
 | `convert_api.get_balances` | `/sapi/v3/asset/getUserAsset` | POST | `needBtcValuation`, `recvWindow`, `timestamp`, `signature` | 5 IP | [User Asset][4] | PASS |
-| `market_data.get_mid_price` | `/api/v3/ticker/bookTicker`, `/api/v3/avgPrice` | GET | `symbol` | 2 | [Market Data endpoints][9] | PASS |
+| `md_rest.mid_price` | `/api/v3/ticker/bookTicker`, `/api/v3/avgPrice` | GET | `symbol` | 2 | [Market Data endpoints][9] | PASS |
+| `md_rest.ticker_price` | `/api/v3/ticker/price` | GET | `symbol` | 2 | [Market Data endpoints → Symbol price ticker][9] | PASS |
+| `md_rest.ticker_24hr` | `/api/v3/ticker/24hr` | GET | `symbol` | 40 | [Market Data endpoints][9] | PASS |
+| `md_rest.klines` | `/api/v3/klines` | GET | `symbol`, `interval`, `limit` | 2 | [Market Data endpoints][9] | PASS |
+| `md_ws.MarketDataWS` | `wss://data-stream.binance.vision/stream` | WS | `streams` | – | [WebSocket Streams][14] | PASS |
 | `binance_api.get_historical_prices` | `/api/v3/klines` | GET | `symbol`, `interval`, `limit` | 2 | [Market Data endpoints][9] | PASS |
 | `exchange_filters.get_last_price_usdt` | `/api/v3/ticker/price` | GET | `symbol` | 2 (1 символ) / 4 (без symbol або з symbols) | [Market Data endpoints → Symbol price ticker][9] | PASS |
 | `risk_off._price_usdt` | `/api/v3/avgPrice`, `/api/v3/ticker/24hr` | GET | `symbol` | 2 | [Market Data endpoints][9] | PASS |
@@ -29,10 +33,10 @@
 
 ## 3) Market-Data Analytics
 Уся аналітика отримується з публічних REST на `data-api.binance.vision`:  
-* `bookTicker` та `avgPrice` для mid‑price【F:market_data.py†L20-L41】 – PASS  
-* `klines` для історичних даних【F:binance_api.py†L46-L75】 – PASS  
-* `ticker/price` для останньої ціни【F:exchange_filters.py†L51-L66】 – PASS  
-* `ticker/24hr` у risk‑off оцінці портфеля【F:risk_off.py†L32-L47】 – PASS
+* `bookTicker` та `avgPrice` для mid‑price【F:md_rest.py†L92-L116】【F:mid_ref.py†L22-L51】 – PASS
+* `klines` для історичних даних та моментуму【F:md_rest.py†L80-L87】 – PASS
+* `ticker/price` для останньої ціни【F:md_rest.py†L52-L57】 – PASS
+* `ticker/24hr` у risk‑off оцінці портфеля та ліквідності【F:md_rest.py†L71-L75】【F:risk_off.py†L32-L47】 – PASS
 **Примітка:** Для API, що повертають лише публічні дані, базова адреса має бути `https://data-api.binance.vision` (без API-ключа)[12].
 Пошук інших Spot‑ендпойнтів не дав результатів【98a565†L1-L2】.
 
@@ -50,7 +54,7 @@
 * `should_throttle` блокує перевищення добового/циклового ліміту та ваги【F:quote_counter.py†L118-L123】【F:convert_cycle.py†L114-L116】 – PASS
 
 ## 7) Mid-price у скорингу
-* `get_mid_price` (bookTicker/avgPrice) використовується для розрахунку `edge`【F:convert_cycle.py†L146-L153】【F:market_data.py†L20-L41】 – PASS
+* `score_pair` використовує Spot mid для розрахунку `edge`【F:convert_cycle.py†L146-L160】【F:scoring.py†L24-L59】 – PASS
 
 ## 8) Risk-off
 * `check_risk` оцінює просідання портфеля на основі балансів і публічних цін; при >10% зменшує ліміт/validTime, при >25% – пауза【F:convert_cycle.py†L42-L58】【F:risk_off.py†L32-L78】 – PASS
@@ -89,3 +93,4 @@ INFO: Виявлених невідповідностей не знайдено;
 [11]: https://developers.binance.com/docs/binance-spot-api-docs/rest-api/request-security?utm_source=chatgpt.com
 [12]: https://developers.binance.com/docs/binance-spot-api-docs/rest-api?utm_source=chatgpt.com
 [13]: https://developers.binance.com/docs/convert/trade/Get-Convert-Trade-History?utm_source=chatgpt.com
+[14]: https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams

--- a/config_dev3.py
+++ b/config_dev3.py
@@ -14,3 +14,13 @@ DEV3_RECV_WINDOW_MS = 5000  # default recvWindow per Binance docs (max 60000)
 CONVERT_SCORE_THRESHOLD = 0.01
 
 CHAT_ID = TELEGRAM_CHAT_ID
+
+# weights for the composite scoring model used in :mod:`scoring`
+# S = w1*edge + w2*liquidity + w3*momentum - w4*spread - w5*volatility
+SCORING_WEIGHTS = {
+    "edge": 1.0,
+    "liquidity": 0.1,
+    "momentum": 0.1,
+    "spread": 0.1,
+    "volatility": 0.1,
+}

--- a/md_rest.py
+++ b/md_rest.py
@@ -1,0 +1,116 @@
+"""Utility wrappers for Binance Spot public REST market data.
+
+All requests use https://data-api.binance.vision and consume official
+request weights. These helpers are intentionally light-weight and rely on
+:mod:`requests` which is already used elsewhere in the project.
+
+Each function includes a reference to the relevant Binance documentation.
+"""
+
+from __future__ import annotations
+
+import requests
+from typing import Any, Dict, List
+
+from quote_counter import record_weight
+
+BASE_URL = "https://data-api.binance.vision"
+
+# --- basic REST helpers ----------------------------------------------------
+
+def _get(path: str, params: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Perform a GET request against ``BASE_URL``.
+
+    Returns ``None`` on HTTP or JSON decode errors. A small timeout is used to
+    avoid hanging the convert cycle.
+    """
+
+    try:
+        resp = requests.get(f"{BASE_URL}{path}", params=params, timeout=10)
+    except Exception:
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        return resp.json()
+    except Exception:
+        return None
+
+
+# --- individual endpoints --------------------------------------------------
+
+# https://developers.binance.com/docs/binance-spot-api-docs/rest-api/market-data-endpoints#current-average-price
+
+def avg_price(symbol: str) -> Dict[str, Any] | None:
+    """Return data from ``GET /api/v3/avgPrice`` (weight **2**)."""
+
+    record_weight("avgPrice")
+    return _get("/api/v3/avgPrice", {"symbol": symbol})
+
+
+# https://developers.binance.com/docs/binance-spot-api-docs/rest-api/market-data-endpoints#symbol-price-ticker
+
+def ticker_price(symbol: str) -> Dict[str, Any] | None:
+    """Return data from ``GET /api/v3/ticker/price`` (weight **2**)."""
+
+    record_weight("ticker/price")
+    return _get("/api/v3/ticker/price", {"symbol": symbol})
+
+
+# https://developers.binance.com/docs/binance-spot-api-docs/rest-api/market-data-endpoints#symbol-order-book-ticker
+
+def book_ticker(symbol: str) -> Dict[str, Any] | None:
+    """Return data from ``GET /api/v3/ticker/bookTicker`` (weight **2**)."""
+
+    record_weight("bookTicker")
+    return _get("/api/v3/ticker/bookTicker", {"symbol": symbol})
+
+
+# https://developers.binance.com/docs/binance-spot-api-docs/rest-api/market-data-endpoints#24hr-ticker-price-change-statistics
+
+def ticker_24hr(symbol: str) -> Dict[str, Any] | None:
+    """Return data from ``GET /api/v3/ticker/24hr`` (weight **40**)."""
+
+    record_weight("ticker/24hr")
+    return _get("/api/v3/ticker/24hr", {"symbol": symbol})
+
+
+# https://developers.binance.com/docs/binance-spot-api-docs/rest-api/market-data-endpoints#klinecandlestick-data
+
+def klines(symbol: str, interval: str, limit: int = 500) -> List[List[Any]] | None:
+    """Return ``GET /api/v3/klines`` (weight **2**).
+
+    ``interval`` follows the Binance kline interval spec, e.g. ``"1m"``.
+    """
+
+    record_weight("klines")
+    return _get("/api/v3/klines", {"symbol": symbol, "interval": interval, "limit": limit})
+
+
+# Convenience mid price helper ----------------------------------------------
+
+def mid_price(symbol: str) -> float | None:
+    """Return mid price for ``symbol`` using bookTicker then avgPrice.
+
+    The book ticker provides best bid/ask; if either side is missing the
+    function falls back to the average price endpoint.
+    """
+
+    data = book_ticker(symbol)
+    if data:
+        try:
+            bid = float(data.get("bidPrice", 0))
+            ask = float(data.get("askPrice", 0))
+            if bid > 0 and ask > 0:
+                return (bid + ask) / 2
+        except Exception:
+            pass
+    data = avg_price(symbol)
+    if data:
+        try:
+            px = float(data.get("price", 0))
+            if px > 0:
+                return px
+        except Exception:
+            pass
+    return None

--- a/md_ws.py
+++ b/md_ws.py
@@ -1,0 +1,95 @@
+"""WebSocket utilities for Binance Spot market data streams.
+
+The module provides a thin manager that can subscribe to multiple streams using
+Binance combined stream URLs. Connections are intended for market-data only and
+use ``wss://data-stream.binance.vision`` as recommended in the Binance
+"Market Data Only" guidelines.
+
+Documentation: https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Callable, List
+
+try:  # ``websocket-client`` is optional during testing
+    import websocket  # type: ignore
+except Exception:  # pragma: no cover - module is optional
+    websocket = None  # type: ignore
+
+PING_INTERVAL = 20  # seconds, Binance requirement
+MAX_MSG_PER_SEC = 5  # incoming rate limit
+BASE_WSS_URL = "wss://data-stream.binance.vision"
+
+
+def build_combined_stream(streams: List[str]) -> str:
+    """Return combined stream URL for ``streams``.
+
+    Example::
+
+        build_combined_stream(["btcusdt@bookTicker", "ethusdt@avgPrice"])
+    """
+
+    stream_path = "/stream?streams=" + "/".join(streams)
+    return f"{BASE_WSS_URL}{stream_path}"
+
+
+class MarketDataWS:
+    """Manage a Binance market-data WebSocket connection.
+
+    The manager keeps track of incoming message counts to enforce the
+    5 msg/s guideline and sends ping frames every 20 seconds. It is intentionally
+    minimal; production code should handle reconnections and resubscriptions
+    after 24h as per Binance limits.
+    """
+
+    def __init__(self, streams: List[str], on_message: Callable[[str], None]):
+        self.streams = streams
+        self.on_message_cb = on_message
+        self.ws = None
+        self._msg_count = 0
+        self._last_sec = int(time.time())
+
+    # --- connection management ---------------------------------------------
+
+    def connect(self) -> None:
+        if websocket is None:  # pragma: no cover - depends on optional lib
+            raise RuntimeError("websocket-client is required for WS operations")
+
+        url = build_combined_stream(self.streams)
+        self.ws = websocket.WebSocketApp(
+            url,
+            on_message=self._handle_message,
+            on_open=lambda ws: self._start_ping_thread(),
+        )
+        self.ws.run_forever()
+
+    # ------------------------------------------------------------------
+
+    def _handle_message(self, ws, message: str) -> None:
+        now = int(time.time())
+        if now != self._last_sec:
+            self._msg_count = 0
+            self._last_sec = now
+        self._msg_count += 1
+        if self._msg_count > MAX_MSG_PER_SEC:
+            ws.close()  # hard stop if flood detected
+            return
+        self.on_message_cb(message)
+
+    # ------------------------------------------------------------------
+
+    def _start_ping_thread(self) -> None:
+        def _run():
+            while self.ws and self.ws.keep_running:
+                try:
+                    self.ws.send(json.dumps({"method": "PING"}))
+                except Exception:
+                    return
+                time.sleep(PING_INTERVAL)
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()

--- a/mid_ref.py
+++ b/mid_ref.py
@@ -1,0 +1,52 @@
+"""Mapping between Convert pairs and Spot market symbols.
+
+The module derives a reference mid price for a Convert pair using Spot market
+prices. It first attempts to use a direct Spot symbol (``FROMTO``). If the
+symbol does not exist, a synthetic cross via stablecoins or ``BTC`` is used.
+
+References:
+- Convert market data: https://developers.binance.com/docs/convert/market-data
+- Spot avgPrice/bookTicker: https://developers.binance.com/docs/binance-spot-api-docs/rest-api/market-data-endpoints
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import md_rest
+
+# Candidate bridge assets for synthetic crosses. Order reflects priority
+BRIDGE_ASSETS = ["USDT", "USDC", "BUSD", "BTC"]
+
+
+def _spot_mid(symbol: str) -> float | None:
+    return md_rest.mid_price(symbol)
+
+
+def _direct_symbol(from_asset: str, to_asset: str) -> str:
+    return f"{from_asset}{to_asset}".upper()
+
+
+def get_mid_price(from_asset: str, to_asset: str, *, with_symbol: bool = False) -> Tuple[float | None, str] | float | None:
+    """Return Spot mid price for the Convert pair ``from_asset``→``to_asset``.
+
+    If ``with_symbol`` is ``True`` the return value is ``(mid, symbol)``.
+    ``symbol`` is the Spot symbol used for the computation (either direct or the
+    first leg when synthetic).
+    """
+
+    symbol = _direct_symbol(from_asset, to_asset)
+    mid = _spot_mid(symbol)
+    if mid is not None:
+        return (mid, symbol) if with_symbol else mid
+
+    # synthetic via bridges
+    for bridge in BRIDGE_ASSETS:
+        if bridge in (from_asset, to_asset):
+            continue
+        leg1 = _spot_mid(_direct_symbol(from_asset, bridge))
+        leg2 = _spot_mid(_direct_symbol(to_asset, bridge))
+        if leg1 and leg2 and leg2 > 0:
+            mid = leg1 / leg2
+            return (mid, symbol) if with_symbol else mid
+    return (None, symbol) if with_symbol else None

--- a/scoring.py
+++ b/scoring.py
@@ -1,0 +1,87 @@
+"""Composite scoring model for Convert pairs.
+
+The score combines edge versus a Spot mid reference with soft penalties for
+spread and volatility as well as liquidity and momentum incentives.
+
+``edge = (quote_ratio - mid_ref) / mid_ref``
+
+The final score is computed as::
+
+    S = w1*edge + w2*liquidity + w3*momentum - w4*spread - w5*volatility
+
+Weight parameters are provided by :mod:`config_dev3` via ``SCORING_WEIGHTS``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import config_dev3
+import md_rest
+import mid_ref
+
+
+def score_pair(from_asset: str, to_asset: str, quote_ratio: float) -> Dict[str, float] | None:
+    """Return score components for the pair.
+
+    All REST market data is fetched via :mod:`md_rest`. Any missing piece simply
+    defaults to ``0`` so that the function never raises due to bad data.
+    """
+
+    mid, symbol = mid_ref.get_mid_price(from_asset, to_asset, with_symbol=True)
+    if not mid:
+        return None
+
+    edge = (quote_ratio - mid) / mid
+
+    bt = md_rest.book_ticker(symbol) or {}
+    try:
+        bid = float(bt.get("bidPrice", 0))
+        ask = float(bt.get("askPrice", 0))
+        spread = (ask - bid) / mid if bid > 0 and ask > 0 else 0.0
+    except Exception:
+        spread = 0.0
+
+    t24 = md_rest.ticker_24hr(symbol) or {}
+    try:
+        liquidity = float(t24.get("quoteVolume", 0))
+        trades = float(t24.get("count", 0))
+        liquidity = liquidity / 1_000_000 + trades / 10_000
+    except Exception:
+        liquidity = 0.0
+
+    kl = md_rest.klines(symbol, "1m", limit=2) or []
+    try:
+        if len(kl) >= 2:
+            open_p = float(kl[-2][1])
+            close_p = float(kl[-1][4])
+            high = float(kl[-1][2])
+            low = float(kl[-1][3])
+            momentum = (close_p - open_p) / open_p if open_p else 0.0
+            volatility = (high - low) / mid if mid else 0.0
+        else:
+            momentum = 0.0
+            volatility = 0.0
+    except Exception:
+        momentum = 0.0
+        volatility = 0.0
+
+    w = config_dev3.SCORING_WEIGHTS
+    score = (
+        w["edge"] * edge
+        + w["liquidity"] * liquidity
+        + w["momentum"] * momentum
+        - w["spread"] * spread
+        - w["volatility"] * volatility
+    )
+
+    return {
+        "symbol": symbol,
+        "mid": mid,
+        "edge": edge,
+        "liquidity": liquidity,
+        "momentum": momentum,
+        "spread": spread,
+        "volatility": volatility,
+        "score": score,
+    }

--- a/tests/test_convert_cycle.py
+++ b/tests/test_convert_cycle.py
@@ -26,7 +26,11 @@ def setup_env(monkeypatch):
     monkeypatch.setattr('config_dev3.DEV3_PAPER_MODE', True)
     monkeypatch.setattr(convert_cycle.config_dev3, 'DEV3_PAPER_MODE', True)
     monkeypatch.setattr(convert_cycle, 'check_risk', lambda: (0, 0))
-    monkeypatch.setattr(convert_cycle, 'get_mid_price', lambda *a, **k: 1.0)
+    monkeypatch.setattr(
+        convert_cycle,
+        'scoring',
+        types.SimpleNamespace(score_pair=lambda f, t, r: {'edge': 0.0, 'score': r}),
+    )
     monkeypatch.setattr(convert_cycle, 'log_cycle_summary', lambda: None)
     monkeypatch.setattr(convert_cycle, 'set_cycle_limit', lambda limit: None)
 

--- a/tests/test_filters_rounding_min_notional.py
+++ b/tests/test_filters_rounding_min_notional.py
@@ -25,7 +25,11 @@ import exchange_filters
 def setup_env(monkeypatch):
     monkeypatch.setattr("config_dev3.DEV3_PAPER_MODE", True)
     monkeypatch.setattr(convert_cycle, "check_risk", lambda: (0, 0))
-    monkeypatch.setattr(convert_cycle, "get_mid_price", lambda *a, **k: 1.0)
+    monkeypatch.setattr(
+        convert_cycle,
+        "scoring",
+        types.SimpleNamespace(score_pair=lambda f, t, r: {"edge": 0.0, "score": r}),
+    )
     monkeypatch.setattr(convert_cycle, "log_cycle_summary", lambda: None)
     monkeypatch.setattr(convert_cycle, "set_cycle_limit", lambda limit: None)
 

--- a/tests/test_md_ws.py
+++ b/tests/test_md_ws.py
@@ -1,0 +1,12 @@
+import os, sys
+sys.path.insert(0, os.getcwd())
+
+from md_ws import build_combined_stream
+
+
+def test_build_combined_stream_url():
+    url = build_combined_stream(["btcusdt@bookTicker", "ethusdt@avgPrice"])
+    assert (
+        url
+        == "wss://data-stream.binance.vision/stream?streams=btcusdt@bookTicker/ethusdt@avgPrice"
+    )

--- a/tests/test_mid_ref.py
+++ b/tests/test_mid_ref.py
@@ -1,0 +1,16 @@
+import os, sys
+sys.path.insert(0, os.getcwd())
+
+import mid_ref
+
+
+def test_direct_symbol(monkeypatch):
+    mapping = {"ETHUSDT": 1000.0}
+    monkeypatch.setattr(mid_ref, "_spot_mid", lambda s: mapping.get(s))
+    assert mid_ref.get_mid_price("ETH", "USDT") == 1000.0
+
+
+def test_cross_via_usdt(monkeypatch):
+    mapping = {"BTCUSDT": 20000.0, "ETHUSDT": 1000.0}
+    monkeypatch.setattr(mid_ref, "_spot_mid", lambda s: mapping.get(s))
+    assert mid_ref.get_mid_price("BTC", "ETH") == 20.0

--- a/tests/test_quote_validity_and_final_status.py
+++ b/tests/test_quote_validity_and_final_status.py
@@ -26,7 +26,11 @@ def setup_env(monkeypatch):
     monkeypatch.setattr("config_dev3.DEV3_PAPER_MODE", True)
     monkeypatch.setattr(convert_cycle.config_dev3, "DEV3_PAPER_MODE", True)
     monkeypatch.setattr(convert_cycle, "check_risk", lambda: (0, 0))
-    monkeypatch.setattr(convert_cycle, "get_mid_price", lambda *a, **k: 1.0)
+    monkeypatch.setattr(
+        convert_cycle,
+        "scoring",
+        types.SimpleNamespace(score_pair=lambda f, t, r: {"edge": 0.0, "score": r}),
+    )
     monkeypatch.setattr(convert_cycle, "log_cycle_summary", lambda: None)
     monkeypatch.setattr(convert_cycle, "set_cycle_limit", lambda limit: None)
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,35 @@
+import os, sys
+sys.path.insert(0, os.getcwd())
+
+import scoring
+import md_rest
+import mid_ref
+import config_dev3
+
+
+def test_score_pair(monkeypatch):
+    def fake_mid(from_asset, to_asset, *, with_symbol=False):
+        if with_symbol:
+            return 10.0, "FT"
+        return 10.0
+
+    monkeypatch.setattr(mid_ref, "get_mid_price", fake_mid)
+    monkeypatch.setattr(md_rest, "book_ticker", lambda s: {"bidPrice": "9", "askPrice": "11"})
+    monkeypatch.setattr(md_rest, "ticker_24hr", lambda s: {"quoteVolume": "1000", "count": "100"})
+    monkeypatch.setattr(
+        md_rest,
+        "klines",
+        lambda s, interval, limit: [[0, "9", "12", "8", "10"], [0, "10", "12", "8", "11"]],
+    )
+    monkeypatch.setattr(
+        config_dev3,
+        "SCORING_WEIGHTS",
+        {"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
+        raising=False,
+    )
+
+    res = scoring.score_pair("F", "T", 10.5)
+    assert res is not None
+    assert abs(res["edge"] - 0.05) < 1e-9
+    expected = 0.05 + 0.0011 + 0.0222222222 - 0.02 - 0.04
+    assert abs(res["score"] - expected) < 1e-6


### PR DESCRIPTION
## Summary
- implement REST wrappers for Binance market data and compute mid prices
- add WebSocket manager with combined streams and message budget
- introduce mid-price mapping and composite scoring integrated into convert cycle
- extend configuration and audit docs for new analytics subsystem

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd46d38fd88329bf7a7c5a119ce022