### PR TITLE
Align market data limits with Binance

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -1,9 +1,10 @@
 import requests
 
 from convert_logger import logger
+from config_dev3 import MARKETDATA_BASE_URL
 
 # Public market data should use the data-api base according to Binance docs
-BASE_URL = "https://data-api.binance.vision"
+BASE_URL = MARKETDATA_BASE_URL
 
 _VALID_SYMBOLS: set[str] | None = None
 try:

--- a/config_dev3.py
+++ b/config_dev3.py
@@ -9,6 +9,9 @@ OPENAI_API_KEY = "<SET_ME>"
 # runtime flags
 DEV3_REGION_TIMER = "ASIA"
 DEV3_RECV_WINDOW_MS = 5000  # default recvWindow per Binance docs (max 60000)
+DEV3_RECV_WINDOW_MAX_MS = 60000
+
+MARKETDATA_BASE_URL = "https://data-api.binance.vision"
 
 CONVERT_SCORE_THRESHOLD = 0.01
 

--- a/exchange_filters.py
+++ b/exchange_filters.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 import requests
 
 import convert_api
+from config_dev3 import MARKETDATA_BASE_URL
 
 
 def load_symbol_filters(
@@ -32,7 +33,7 @@ def get_last_price_usdt(asset: str):
     """Return last price of ASSETUSDT pair as Decimal or ``None`` if missing."""
     try:
         r = requests.get(
-            "https://data-api.binance.vision/api/v3/ticker/price",
+            f"{MARKETDATA_BASE_URL}/api/v3/ticker/price",
             params={"symbol": f"{asset}USDT"},
             timeout=10,
         )

--- a/market_data.py
+++ b/market_data.py
@@ -1,7 +1,8 @@
 import requests
 from quote_counter import record_weight
+from config_dev3 import MARKETDATA_BASE_URL
 
-BASE_URL = "https://data-api.binance.vision"
+BASE_URL = MARKETDATA_BASE_URL
 
 
 def _get(path: str, params: dict) -> dict | None:

--- a/quote_counter.py
+++ b/quote_counter.py
@@ -22,7 +22,6 @@ WEIGHTS = {
     "avgPrice": 2,
     "bookTicker": 2,
     "ticker/price": 2,
-    "ticker/24hr": 40,
     "klines": 2,
 }
 
@@ -30,6 +29,15 @@ _cycle_count = 0
 _cycle_weight = 0
 _cycle_breakdown: dict[str, int] = {}
 _max_per_cycle = DEFAULT_MAX_PER_CYCLE
+
+
+def weight_ticker_24hr(params: dict) -> int:
+    """Return official weight for ``ticker/24hr`` based on parameters."""
+    if params.get("symbol"):
+        return 2
+    if params.get("symbols"):
+        return 40
+    return 80
 
 
 def _load() -> dict:
@@ -94,10 +102,10 @@ def set_cycle_limit(limit: int) -> None:
     _max_per_cycle = max(1, int(limit))
 
 
-def record_weight(endpoint: str) -> None:
+def record_weight(endpoint: str, weight: int | None = None) -> None:
     """Record weight usage for a given endpoint."""
     global _cycle_weight, _cycle_breakdown
-    w = WEIGHTS.get(endpoint, 1)
+    w = weight if weight is not None else WEIGHTS.get(endpoint, 1)
     _cycle_weight += w
     _cycle_breakdown[endpoint] = _cycle_breakdown.get(endpoint, 0) + w
 

--- a/risk_off.py
+++ b/risk_off.py
@@ -6,8 +6,9 @@ import requests
 
 from convert_api import get_balances
 from quote_counter import record_weight
+from config_dev3 import MARKETDATA_BASE_URL
 
-BASE_URL = "https://data-api.binance.vision"
+BASE_URL = MARKETDATA_BASE_URL
 HIGH_FILE = os.path.join("logs", "portfolio_high.json")
 DRAWDOWN_THRESHOLD = 0.10
 PAUSE_THRESHOLD = 0.25
@@ -40,7 +41,7 @@ def _price_usdt(asset: str) -> float:
             return float(r.json().get("price", 0))
     except Exception:
         pass
-    record_weight("ticker/24hr")
+    record_weight("ticker/24hr", 2)
     try:
         r = requests.get(f"{BASE_URL}/api/v3/ticker/24hr", params={"symbol": symbol}, timeout=10)
         if r.status_code == 200:

--- a/tests/test_convert_cycle.py
+++ b/tests/test_convert_cycle.py
@@ -17,6 +17,9 @@ sys.modules.setdefault(
         CHAT_ID='',
         DEV3_REGION_TIMER='ASIA',
         DEV3_RECV_WINDOW_MS=5000,
+        DEV3_RECV_WINDOW_MAX_MS=60000,
+        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     ),
 )
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -12,6 +12,9 @@ def _setup_cfg(monkeypatch, key="k", secret="s"):
         CHAT_ID="",
         DEV3_REGION_TIMER="ASIA",
         DEV3_RECV_WINDOW_MS=5000,
+        DEV3_RECV_WINDOW_MAX_MS=60000,
+        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     )
     monkeypatch.setitem(sys.modules, "config_dev3", cfg)
 

--- a/tests/test_filters_rounding_min_notional.py
+++ b/tests/test_filters_rounding_min_notional.py
@@ -12,6 +12,9 @@ sys.modules.setdefault(
         CHAT_ID="",
         DEV3_REGION_TIMER="ASIA",
         DEV3_RECV_WINDOW_MS=5000,
+        DEV3_RECV_WINDOW_MAX_MS=60000,
+        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     ),
 )
 

--- a/tests/test_md_rest_weights.py
+++ b/tests/test_md_rest_weights.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.getcwd())
+
+from quote_counter import weight_ticker_24hr
+import md_rest
+
+
+def test_weight_ticker_24hr_single():
+    assert weight_ticker_24hr({"symbol": "BTCUSDT"}) == 2
+
+
+def test_weight_ticker_24hr_multi():
+    assert weight_ticker_24hr({"symbols": "[\"BTCUSDT\"]"}) == 40
+
+
+def test_ticker_24hr_requires_params():
+    with pytest.raises(ValueError):
+        md_rest.ticker_24hr()

--- a/tests/test_quote_validity_and_final_status.py
+++ b/tests/test_quote_validity_and_final_status.py
@@ -12,6 +12,9 @@ sys.modules.setdefault(
         CHAT_ID="",
         DEV3_REGION_TIMER="ASIA",
         DEV3_RECV_WINDOW_MS=5000,
+        DEV3_RECV_WINDOW_MAX_MS=60000,
+        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     ),
 )
 

--- a/tests/test_recv_window_and_-1021_retry.py
+++ b/tests/test_recv_window_and_-1021_retry.py
@@ -12,6 +12,9 @@ sys.modules.setdefault(
         CHAT_ID="",
         DEV3_REGION_TIMER="ASIA",
         DEV3_RECV_WINDOW_MS=5000,
+        DEV3_RECV_WINDOW_MAX_MS=60000,
+        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     ),
 )
 

--- a/tests/test_recv_window_clamp.py
+++ b/tests/test_recv_window_clamp.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import types
+import pytest
+
+sys.modules['config_dev3'] = types.SimpleNamespace(
+    BINANCE_API_KEY='k',
+    BINANCE_API_SECRET='s',
+    OPENAI_API_KEY='',
+    TELEGRAM_TOKEN='',
+    CHAT_ID='',
+    DEV3_REGION_TIMER='ASIA',
+    DEV3_RECV_WINDOW_MS=5000,
+    DEV3_RECV_WINDOW_MAX_MS=60000,
+    MARKETDATA_BASE_URL='https://data-api.binance.vision',
+    SCORING_WEIGHTS={'edge': 1.0, 'liquidity': 0.1, 'momentum': 0.1, 'spread': 0.1, 'volatility': 0.1},
+)
+
+sys.path.insert(0, os.getcwd())
+import importlib
+import convert_api
+importlib.reload(convert_api)
+
+
+def test_recv_window_clamped(monkeypatch):
+    monkeypatch.setattr(convert_api, '_current_timestamp', lambda: 0)
+    params = convert_api._build_signed_params({'recvWindow': 120000})
+    assert params['recvWindow'] == 60000
+
+
+def test_recv_window_default(monkeypatch):
+    monkeypatch.setattr(convert_api, '_current_timestamp', lambda: 0)
+    params = convert_api._build_signed_params({})
+    assert params['recvWindow'] == 5000

--- a/tests/test_tradeflow_reconcile.py
+++ b/tests/test_tradeflow_reconcile.py
@@ -13,6 +13,9 @@ sys.modules.setdefault(
         CHAT_ID="",
         DEV3_REGION_TIMER="ASIA",
         DEV3_RECV_WINDOW_MS=5000,
+        DEV3_RECV_WINDOW_MAX_MS=60000,
+        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     ),
 )
 

--- a/tests/test_tradeflow_span.py
+++ b/tests/test_tradeflow_span.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import types
+import pytest
+
+sys.modules['config_dev3'] = types.SimpleNamespace(
+    BINANCE_API_KEY='k',
+    BINANCE_API_SECRET='s',
+    OPENAI_API_KEY='',
+    TELEGRAM_TOKEN='',
+    CHAT_ID='',
+    DEV3_REGION_TIMER='ASIA',
+    DEV3_RECV_WINDOW_MS=5000,
+    DEV3_RECV_WINDOW_MAX_MS=60000,
+    MARKETDATA_BASE_URL='https://data-api.binance.vision',
+    SCORING_WEIGHTS={'edge': 1.0, 'liquidity': 0.1, 'momentum': 0.1, 'spread': 0.1, 'volatility': 0.1},
+)
+
+sys.path.insert(0, os.getcwd())
+import importlib
+import convert_api
+importlib.reload(convert_api)
+
+
+def test_tradeflow_span_limit():
+    span = 31 * 24 * 60 * 60 * 1000 + 1
+    with pytest.raises(ValueError):
+        convert_api.trade_flow(0, span)


### PR DESCRIPTION
## Summary
- Add parameter-aware 24hr ticker helper and dynamic weight tracking
- Clamp signed request recvWindow to 60s and guard tradeFlow range
- Centralise market data base URL on data-api.binance.vision

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd507b680483298a472370a47f18ca