### PR TITLE
Refactor Binance config and weight handling

### DIFF
--- a/binance_api.py
+++ b/binance_api.py
@@ -1,10 +1,10 @@
 import requests
 
 from convert_logger import logger
-from config_dev3 import MARKETDATA_BASE_URL
+from config_dev3 import MARKETDATA_BASE
 
 # Public market data should use the data-api base according to Binance docs
-BASE_URL = MARKETDATA_BASE_URL
+BASE_URL = MARKETDATA_BASE
 
 _VALID_SYMBOLS: set[str] | None = None
 try:

--- a/config_dev3.py
+++ b/config_dev3.py
@@ -11,7 +11,12 @@ DEV3_REGION_TIMER = "ASIA"
 DEV3_RECV_WINDOW_MS = 5000  # default recvWindow per Binance docs (max 60000)
 DEV3_RECV_WINDOW_MAX_MS = 60000
 
-MARKETDATA_BASE_URL = "https://data-api.binance.vision"
+# base URLs
+API_BASE = "https://api.binance.com"  # SIGNED/SAPI
+MARKETDATA_BASE = "https://data-api.binance.vision"  # public Spot REST
+
+# production mode by default
+PAPER_MODE = False
 
 CONVERT_SCORE_THRESHOLD = 0.01
 

--- a/convert_api.py
+++ b/convert_api.py
@@ -27,14 +27,15 @@ from config_dev3 import (
     BINANCE_API_SECRET,
     DEV3_RECV_WINDOW_MS,
     DEV3_RECV_WINDOW_MAX_MS,
+    API_BASE,
 )
 
 from utils_dev3 import get_current_timestamp
 from quote_counter import increment_quote_usage, record_weight
 
 
-# Convert endpoints always live under the main API domain; use fixed defaults
-BASE_URL = "https://api.binance.com"
+# Convert endpoints always live under the main API domain; use configured base
+BASE_URL = API_BASE
 DEFAULT_RECV_WINDOW = DEV3_RECV_WINDOW_MS
 
 # requests session with a tiny retry just for connection errors.  Rate limit

--- a/market_data.py
+++ b/market_data.py
@@ -1,8 +1,8 @@
 import requests
-from quote_counter import record_weight
-from config_dev3 import MARKETDATA_BASE_URL
+from quote_counter import record_weight, weight_book_ticker
+from config_dev3 import MARKETDATA_BASE
 
-BASE_URL = MARKETDATA_BASE_URL
+BASE_URL = MARKETDATA_BASE
 
 
 def _get(path: str, params: dict) -> dict | None:
@@ -20,8 +20,9 @@ def _get(path: str, params: dict) -> dict | None:
 
 def get_mid_price(from_asset: str, to_asset: str) -> float | None:
     symbol = f"{from_asset}{to_asset}"
-    record_weight("bookTicker")
-    data = _get("/api/v3/ticker/bookTicker", {"symbol": symbol})
+    params = {"symbol": symbol}
+    record_weight("bookTicker", weight_book_ticker(params))
+    data = _get("/api/v3/ticker/bookTicker", params)
     if data:
         try:
             bid = float(data.get("bidPrice", 0))

--- a/quote_counter.py
+++ b/quote_counter.py
@@ -20,8 +20,6 @@ WEIGHTS = {
     "assetInfo": 100,
     "getUserAsset": 5,
     "avgPrice": 2,
-    "bookTicker": 2,
-    "ticker/price": 2,
     "klines": 2,
 }
 
@@ -36,8 +34,21 @@ def weight_ticker_24hr(params: dict) -> int:
     if params.get("symbol"):
         return 2
     if params.get("symbols"):
-        return 40
+        n = len(json.loads(params["symbols"]))
+        if n <= 20:
+            return 2
+        return 40 if n <= 100 else 80
     return 80
+
+
+def weight_ticker_price(params: dict) -> int:
+    """Return weight for ``ticker/price`` based on parameters."""
+    return 2 if params.get("symbol") else 4
+
+
+def weight_book_ticker(params: dict) -> int:
+    """Return weight for ``ticker/bookTicker`` based on parameters."""
+    return 2 if params.get("symbol") else 4
 
 
 def _load() -> dict:

--- a/risk_off.py
+++ b/risk_off.py
@@ -5,10 +5,10 @@ from typing import Tuple
 import requests
 
 from convert_api import get_balances
-from quote_counter import record_weight
-from config_dev3 import MARKETDATA_BASE_URL
+from quote_counter import record_weight, weight_ticker_24hr
+from config_dev3 import MARKETDATA_BASE
 
-BASE_URL = MARKETDATA_BASE_URL
+BASE_URL = MARKETDATA_BASE
 HIGH_FILE = os.path.join("logs", "portfolio_high.json")
 DRAWDOWN_THRESHOLD = 0.10
 PAUSE_THRESHOLD = 0.25
@@ -41,9 +41,10 @@ def _price_usdt(asset: str) -> float:
             return float(r.json().get("price", 0))
     except Exception:
         pass
-    record_weight("ticker/24hr", 2)
+    params = {"symbol": symbol}
+    record_weight("ticker/24hr", weight_ticker_24hr(params))
     try:
-        r = requests.get(f"{BASE_URL}/api/v3/ticker/24hr", params={"symbol": symbol}, timeout=10)
+        r = requests.get(f"{BASE_URL}/api/v3/ticker/24hr", params=params, timeout=10)
         if r.status_code == 200:
             return float(r.json().get("lastPrice", 0))
     except Exception:

--- a/tests/test_convert_api.py
+++ b/tests/test_convert_api.py
@@ -18,7 +18,8 @@ sys.modules.setdefault(
         DEV3_REGION_TIMER="ASIA",
         DEV3_RECV_WINDOW_MS=5000,
         DEV3_RECV_WINDOW_MAX_MS=60000,
-        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        API_BASE="https://api.binance.com",
+        MARKETDATA_BASE="https://data-api.binance.vision",
         SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     ),
 )

--- a/tests/test_convert_cycle.py
+++ b/tests/test_convert_cycle.py
@@ -18,7 +18,8 @@ sys.modules.setdefault(
         DEV3_REGION_TIMER='ASIA',
         DEV3_RECV_WINDOW_MS=5000,
         DEV3_RECV_WINDOW_MAX_MS=60000,
-        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        API_BASE="https://api.binance.com",
+        MARKETDATA_BASE="https://data-api.binance.vision",
         SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     ),
 )
@@ -33,6 +34,8 @@ def setup_env(monkeypatch):
     )
     monkeypatch.setattr(convert_cycle, 'log_cycle_summary', lambda: None)
     monkeypatch.setattr(convert_cycle, 'set_cycle_limit', lambda limit: None)
+    monkeypatch.setattr(convert_cycle, 'load_symbol_filters', lambda *a, **k: (None, None, None))
+    monkeypatch.setattr(convert_cycle, 'get_last_price_usdt', lambda *a, **k: None)
 
 
 def test_process_pair_success(monkeypatch):

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -13,7 +13,8 @@ def _setup_cfg(monkeypatch, key="k", secret="s"):
         DEV3_REGION_TIMER="ASIA",
         DEV3_RECV_WINDOW_MS=5000,
         DEV3_RECV_WINDOW_MAX_MS=60000,
-        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        API_BASE="https://api.binance.com",
+        MARKETDATA_BASE="https://data-api.binance.vision",
         SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     )
     monkeypatch.setitem(sys.modules, "config_dev3", cfg)

--- a/tests/test_filters_rounding_min_notional.py
+++ b/tests/test_filters_rounding_min_notional.py
@@ -13,7 +13,8 @@ sys.modules.setdefault(
         DEV3_REGION_TIMER="ASIA",
         DEV3_RECV_WINDOW_MS=5000,
         DEV3_RECV_WINDOW_MAX_MS=60000,
-        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        API_BASE="https://api.binance.com",
+        MARKETDATA_BASE="https://data-api.binance.vision",
         SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     ),
 )

--- a/tests/test_md_rest_weights.py
+++ b/tests/test_md_rest_weights.py
@@ -1,21 +1,61 @@
 import os
 import sys
+import types
+import json
 import pytest
+
+
+sys.modules.setdefault(
+    "config_dev3",
+    types.SimpleNamespace(
+        BINANCE_API_KEY="k",
+        BINANCE_API_SECRET="s",
+        OPENAI_API_KEY="",
+        TELEGRAM_TOKEN="",
+        CHAT_ID="",
+        DEV3_REGION_TIMER="ASIA",
+        DEV3_RECV_WINDOW_MS=5000,
+        DEV3_RECV_WINDOW_MAX_MS=60000,
+        API_BASE="https://api.binance.com",
+        MARKETDATA_BASE="https://data-api.binance.vision",
+        SCORING_WEIGHTS={
+            "edge": 1.0,
+            "liquidity": 0.1,
+            "momentum": 0.1,
+            "spread": 0.1,
+            "volatility": 0.1,
+        },
+    ),
+)
 
 sys.path.insert(0, os.getcwd())
 
-from quote_counter import weight_ticker_24hr
+from quote_counter import (
+    weight_ticker_24hr,
+    weight_ticker_price,
+    weight_book_ticker,
+)
 import md_rest
 
 
-def test_weight_ticker_24hr_single():
+def test_weight_ticker_24hr():
     assert weight_ticker_24hr({"symbol": "BTCUSDT"}) == 2
-
-
-def test_weight_ticker_24hr_multi():
-    assert weight_ticker_24hr({"symbols": "[\"BTCUSDT\"]"}) == 40
-
-
-def test_ticker_24hr_requires_params():
+    symbols = json.dumps([f"ASSET{i}" for i in range(30)])
+    assert weight_ticker_24hr({"symbols": symbols}) == 40
     with pytest.raises(ValueError):
         md_rest.ticker_24hr()
+
+
+def test_weight_ticker_price_and_guard():
+    assert weight_ticker_price({"symbol": "BTCUSDT"}) == 2
+    assert weight_ticker_price({}) == 4
+    with pytest.raises(ValueError):
+        md_rest.ticker_price()
+
+
+def test_weight_book_ticker_and_guard():
+    assert weight_book_ticker({"symbol": "BTCUSDT"}) == 2
+    assert weight_book_ticker({}) == 4
+    with pytest.raises(ValueError):
+        md_rest.book_ticker()
+

--- a/tests/test_quote_validity_and_final_status.py
+++ b/tests/test_quote_validity_and_final_status.py
@@ -13,7 +13,8 @@ sys.modules.setdefault(
         DEV3_REGION_TIMER="ASIA",
         DEV3_RECV_WINDOW_MS=5000,
         DEV3_RECV_WINDOW_MAX_MS=60000,
-        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        API_BASE="https://api.binance.com",
+        MARKETDATA_BASE="https://data-api.binance.vision",
         SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     ),
 )
@@ -39,7 +40,7 @@ def test_expired_quote_skipped(monkeypatch):
     setup_env(monkeypatch)
     monkeypatch.setattr(convert_cycle, "reset_cycle", lambda: None)
     monkeypatch.setattr(convert_cycle, "should_throttle", lambda *a, **k: False)
-    monkeypatch.setattr(convert_cycle, "load_symbol_filters", lambda *a, **k: (None, None))
+    monkeypatch.setattr(convert_cycle, "load_symbol_filters", lambda *a, **k: (None, None, None))
     monkeypatch.setattr(convert_cycle, "get_last_price_usdt", lambda *a, **k: None)
     monkeypatch.setattr(
         convert_cycle, "filter_top_tokens", lambda tokens, score_threshold, top_n=2: list(tokens.items())
@@ -68,7 +69,7 @@ def test_only_success_recorded(monkeypatch):
     setup_env(monkeypatch)
     monkeypatch.setattr(convert_cycle, "reset_cycle", lambda: None)
     monkeypatch.setattr(convert_cycle, "should_throttle", lambda *a, **k: False)
-    monkeypatch.setattr(convert_cycle, "load_symbol_filters", lambda *a, **k: (None, None))
+    monkeypatch.setattr(convert_cycle, "load_symbol_filters", lambda *a, **k: (None, None, None))
     monkeypatch.setattr(convert_cycle, "get_last_price_usdt", lambda *a, **k: None)
     monkeypatch.setattr(
         convert_cycle, "filter_top_tokens", lambda tokens, score_threshold, top_n=2: list(tokens.items())

--- a/tests/test_recv_window_and_-1021_retry.py
+++ b/tests/test_recv_window_and_-1021_retry.py
@@ -13,7 +13,8 @@ sys.modules.setdefault(
         DEV3_REGION_TIMER="ASIA",
         DEV3_RECV_WINDOW_MS=5000,
         DEV3_RECV_WINDOW_MAX_MS=60000,
-        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        API_BASE="https://api.binance.com",
+        MARKETDATA_BASE="https://data-api.binance.vision",
         SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     ),
 )

--- a/tests/test_recv_window_clamp.py
+++ b/tests/test_recv_window_clamp.py
@@ -12,7 +12,8 @@ sys.modules['config_dev3'] = types.SimpleNamespace(
     DEV3_REGION_TIMER='ASIA',
     DEV3_RECV_WINDOW_MS=5000,
     DEV3_RECV_WINDOW_MAX_MS=60000,
-    MARKETDATA_BASE_URL='https://data-api.binance.vision',
+    API_BASE='https://api.binance.com',
+    MARKETDATA_BASE='https://data-api.binance.vision',
     SCORING_WEIGHTS={'edge': 1.0, 'liquidity': 0.1, 'momentum': 0.1, 'spread': 0.1, 'volatility': 0.1},
 )
 

--- a/tests/test_tradeflow_reconcile.py
+++ b/tests/test_tradeflow_reconcile.py
@@ -14,7 +14,8 @@ sys.modules.setdefault(
         DEV3_REGION_TIMER="ASIA",
         DEV3_RECV_WINDOW_MS=5000,
         DEV3_RECV_WINDOW_MAX_MS=60000,
-        MARKETDATA_BASE_URL="https://data-api.binance.vision",
+        API_BASE="https://api.binance.com",
+        MARKETDATA_BASE="https://data-api.binance.vision",
         SCORING_WEIGHTS={"edge": 1.0, "liquidity": 0.1, "momentum": 0.1, "spread": 0.1, "volatility": 0.1},
     ),
 )

--- a/tests/test_tradeflow_span.py
+++ b/tests/test_tradeflow_span.py
@@ -12,7 +12,8 @@ sys.modules['config_dev3'] = types.SimpleNamespace(
     DEV3_REGION_TIMER='ASIA',
     DEV3_RECV_WINDOW_MS=5000,
     DEV3_RECV_WINDOW_MAX_MS=60000,
-    MARKETDATA_BASE_URL='https://data-api.binance.vision',
+    API_BASE='https://api.binance.com',
+    MARKETDATA_BASE='https://data-api.binance.vision',
     SCORING_WEIGHTS={'edge': 1.0, 'liquidity': 0.1, 'momentum': 0.1, 'spread': 0.1, 'volatility': 0.1},
 )
 


### PR DESCRIPTION
## Summary
- centralize Binance endpoints and flags in config_dev3
- clamp recvWindow and add Convert min/max guards with re-quote validity
- enforce parameter-sensitive Spot weights and guards for market data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be729582348329838291d5fa6d3354