### PR TITLE
Implement convert portfolio pipeline with guard

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -198,7 +198,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_run = sub.add_parser("run", help="Invoke auto-cycle phase")
     p_run.add_argument("--region", required=True, choices=["asia", "us"])
-    p_run.add_argument("--phase", required=True, choices=["analyze", "trade"])
+    p_run.add_argument(
+        "--phase",
+        required=True,
+        choices=["pre-analyze", "analyze", "trade", "guard"],
+    )
     p_run.add_argument(
         "--dry-run", dest="dry_run", type=int, choices=[0, 1], default=None
     )

--- a/src/core/convert_api.py
+++ b/src/core/convert_api.py
@@ -1,35 +1,322 @@
-from typing import Dict, Any
-from src.core import binance_client
+"""High level helpers around Binance Convert endpoints."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import requests
+
+import config_dev3 as config
+
+from . import binance_client
+from .utils import (
+    DECIMAL_ZERO,
+    decimal_from_any,
+    ensure_amount_and_limits,
+    now_ms,
+    rand_jitter,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+HUB_ASSETS: Tuple[str, ...] = ("BTC", "ETH", "BNB", "USDT")
+
+_JITTER_RANGE_SEC: Tuple[float, float] = tuple(
+    x / 1000.0 for x in getattr(config, "CONVERT_JITTER_MS", (500, 1200))
+) or (0.5, 1.2)
+_QUOTE_TTL_SAFETY_MS = getattr(config, "QUOTE_TTL_SAFETY_MS", 1200)
+_QUOTE_RETRY_MAX = getattr(config, "QUOTE_RETRY_MAX", 2)
+
+# Deduplication cache within process execution
+_executed_keys: set[str] = set()
 
 
-def get_exchange_info(from_asset: str, to_asset: str) -> Dict[str, Any]:
-    # Кешований виклик у binance_client
-    return binance_client.get_convert_exchange_info(from_asset, to_asset)
+@dataclass(frozen=True)
+class ConvertStep:
+    """Single hop in convert route."""
+
+    from_asset: str
+    to_asset: str
 
 
-def get_quote(
-    from_asset: str, to_asset: str, amount: float, wallet: str
-) -> Dict[str, Any]:
-    w = (wallet or "SPOT").upper()
-    if w not in ("SPOT", "FUNDING"):
-        raise ValueError("wallet must be SPOT or FUNDING")
+@dataclass
+class ConvertRoute:
+    """Concrete convert route possibly containing hub assets."""
+
+    steps: Tuple[ConvertStep, ...]
+
+    @property
+    def is_direct(self) -> bool:
+        return len(self.steps) == 1
+
+    @property
+    def description(self) -> str:
+        if self.is_direct:
+            step = self.steps[0]
+            return f"direct:{step.from_asset}->{step.to_asset}"
+        hubs = ",".join(step.to_asset for step in self.steps[:-1])
+        return f"hub:{hubs}"
+
+
+@dataclass
+class ConvertLimits:
+    """Convert limits (min/max) in *from* asset units."""
+
+    minimum: Decimal
+    maximum: Decimal
+
+
+@dataclass
+class ConvertQuote:
+    """Structured representation of Convert quote response."""
+
+    quote_id: str
+    from_asset: str
+    to_asset: str
+    from_amount: Decimal
+    to_amount: Decimal
+    price: Decimal
+    expire_time_ms: int
+    raw: Dict[str, Any]
+
+    def expired(self, safety_ms: int = _QUOTE_TTL_SAFETY_MS) -> bool:
+        if not self.expire_time_ms:
+            return False
+        return now_ms() >= max(0, self.expire_time_ms - int(abs(safety_ms)))
+
+
+def _sleep_with_jitter() -> None:
+    jitter = rand_jitter(_JITTER_RANGE_SEC)
+    if jitter > 0:
+        time.sleep(jitter)
+
+
+def _normalise_asset(value: str) -> str:
+    return (value or "").upper().strip()
+
+
+def _safe_exchange_info(from_asset: str, to_asset: str) -> Optional[Dict[str, Any]]:
+    try:
+        return binance_client.get_convert_exchange_info(from_asset, to_asset)
+    except requests.HTTPError as exc:
+        if exc.response is not None and exc.response.status_code in (400, 404):
+            return None
+        raise
+    except requests.RequestException:
+        raise
+
+
+def _extract_limits(info: Optional[Dict[str, Any]]) -> ConvertLimits:
+    if not info:
+        return ConvertLimits(DECIMAL_ZERO, DECIMAL_ZERO)
+    payload: Any = info
+    if isinstance(info, dict) and "data" in info:
+        payload = info.get("data")
+    if not isinstance(payload, dict):
+        payload = {}
+    minimum = decimal_from_any(payload.get("fromAssetMinAmount"))
+    maximum = decimal_from_any(payload.get("fromAssetMaxAmount"))
+    return ConvertLimits(minimum, maximum)
+
+
+def _route_steps(from_asset: str, to_asset: str) -> Optional[ConvertRoute]:
+    if from_asset == to_asset:
+        return ConvertRoute((ConvertStep(from_asset, to_asset),))
+    info = _safe_exchange_info(from_asset, to_asset)
+    if info:
+        return ConvertRoute((ConvertStep(from_asset, to_asset),))
+    for hub in HUB_ASSETS:
+        if hub in (from_asset, to_asset):
+            continue
+        first = _safe_exchange_info(from_asset, hub)
+        if not first:
+            continue
+        second = _safe_exchange_info(hub, to_asset)
+        if not second:
+            continue
+        return ConvertRoute((ConvertStep(from_asset, hub), ConvertStep(hub, to_asset)))
+    return None
+
+
+def route_exists(from_asset: str, to_asset: str) -> Optional[ConvertRoute]:
+    """Return :class:`ConvertRoute` if conversion possible."""
+
+    from_asset = _normalise_asset(from_asset)
+    to_asset = _normalise_asset(to_asset)
+    if not from_asset or not to_asset:
+        return None
+    return _route_steps(from_asset, to_asset)
+
+
+def limits_for_pair(from_asset: str, to_asset: str) -> ConvertLimits:
+    return _extract_limits(_safe_exchange_info(from_asset, to_asset))
+
+
+def get_asset_precision(asset: str) -> Dict[str, Any]:
+    return binance_client.get_convert_asset_info(asset)
+
+
+def _quote_once(
+    from_asset: str,
+    to_asset: str,
+    amount: Decimal,
+    wallet: str = "SPOT",
+    allow_insufficient: bool = False,
+) -> Optional[ConvertQuote]:
     params = {
         "fromAsset": from_asset,
         "toAsset": to_asset,
         "fromAmount": str(amount),
-        "walletType": w,
+        "walletType": (wallet or "SPOT").upper(),
     }
-    # Повертає dict (або кине HTTP/RequestException нагору)
-    return binance_client.post("/sapi/v1/convert/getQuote", params, signed=True)
-
-
-def accept_quote(quote_id: str, *_, **__) -> Dict[str, Any]:
-    return binance_client.post(
-        "/sapi/v1/convert/acceptQuote", {"quoteId": quote_id}, signed=True
+    _sleep_with_jitter()
+    payload = binance_client.post("/sapi/v1/convert/getQuote", params, signed=True)
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("insufficient") and not allow_insufficient:
+        return None
+    expire_raw = payload.get("expireTime") or payload.get("validTimestamp")
+    expire_ms = int(expire_raw) if expire_raw else 0
+    price = decimal_from_any(payload.get("ratio") or payload.get("price"))
+    to_amount = decimal_from_any(payload.get("toAmount") or payload.get("toAmountExpected"))
+    quote = ConvertQuote(
+        quote_id=str(payload.get("quoteId", "")),
+        from_asset=from_asset,
+        to_asset=to_asset,
+        from_amount=decimal_from_any(amount),
+        to_amount=to_amount,
+        price=price,
+        expire_time_ms=expire_ms,
+        raw=payload,
     )
+    return quote
+
+
+def get_quote(
+    from_asset: str,
+    to_asset: str,
+    amount: Decimal,
+    wallet: str = "SPOT",
+    retry: int | None = None,
+) -> Optional[ConvertQuote]:
+    """Fetch Convert quote with TTL-awareness and retries."""
+
+    attempts = retry if retry is not None else max(1, _QUOTE_RETRY_MAX)
+    for attempt in range(1, attempts + 1):
+        quote = _quote_once(from_asset, to_asset, amount, wallet)
+        if quote:
+            return quote
+        if attempt < attempts:
+            _sleep_with_jitter()
+    return None
+
+
+def accept_quote(quote: ConvertQuote | str) -> Dict[str, Any]:
+    quote_id = quote if isinstance(quote, str) else quote.quote_id
+    return binance_client.post("/sapi/v1/convert/acceptQuote", {"quoteId": quote_id}, signed=True)
 
 
 def order_status(order_id: str) -> Dict[str, Any]:
     return binance_client.get(
         "/sapi/v1/convert/orderStatus", {"orderId": order_id}, signed=True
     )
+
+
+def execute_conversion(
+    from_asset: str,
+    to_asset: str,
+    amount: Decimal,
+    wallet: str = "SPOT",
+    retry: int | None = None,
+) -> Dict[str, Any]:
+    """Execute direct conversion (single hop)."""
+
+    info = _safe_exchange_info(from_asset, to_asset)
+    if info:
+        ensure_amount_and_limits(info, amount)
+    quote = get_quote(from_asset, to_asset, amount, wallet, retry=retry)
+    if not quote:
+        raise RuntimeError(f"quote failed for {from_asset}->{to_asset}")
+    if quote.expired():
+        LOGGER.warning(
+            "Quote %s expired immediately, requesting a new one", quote.quote_id
+        )
+        quote = get_quote(from_asset, to_asset, amount, wallet, retry=retry)
+        if not quote:
+            raise RuntimeError("quote failed after retry")
+    result = accept_quote(quote)
+    result.setdefault("quote", quote.raw)
+    return result
+
+
+def execute_route(
+    route: ConvertRoute,
+    amount: Decimal,
+    wallet: str = "SPOT",
+    retry: int | None = None,
+) -> List[Dict[str, Any]]:
+    """Execute route (direct or hub) returning list of order payloads."""
+
+    executed: List[Dict[str, Any]] = []
+    current_amount = amount
+    for step in route.steps:
+        response = execute_conversion(step.from_asset, step.to_asset, current_amount, wallet, retry)
+        executed.append(response)
+        quote = response.get("quote", {})
+        current_amount = decimal_from_any(quote.get("toAmount") or quote.get("toAmountExpected"))
+        wallet = (wallet or "SPOT").upper()
+    return executed
+
+
+def execute_unique(route: ConvertRoute, amount: Decimal, wallet: str, tolerance: float = 0.01) -> Optional[List[Dict[str, Any]]]:
+    key = json.dumps(
+        {
+            "route": [f"{step.from_asset}->{step.to_asset}" for step in route.steps],
+            "amount": float(amount),
+            "wallet": wallet,
+        },
+        sort_keys=True,
+    )
+    for existing in list(_executed_keys):
+        try:
+            payload = json.loads(existing)
+        except Exception:
+            continue
+        if payload.get("wallet") != wallet:
+            continue
+        if payload.get("route") != [f"{step.from_asset}->{step.to_asset}" for step in route.steps]:
+            continue
+        prev_amount = float(payload.get("amount", 0.0))
+        if prev_amount <= 0:
+            continue
+        diff = abs(prev_amount - float(amount)) / prev_amount
+        if diff <= tolerance:
+            LOGGER.info("Skip duplicate convert %s (within %.2f%%)", route.description, tolerance * 100)
+            return None
+    _executed_keys.add(key)
+    return execute_route(route, amount, wallet)
+
+
+def reset_dedup_cache() -> None:
+    _executed_keys.clear()
+
+
+def preferred_route(from_assets: Iterable[str], target: str) -> Optional[ConvertRoute]:
+    target = _normalise_asset(target)
+    for asset in { _normalise_asset(a) for a in from_assets }:
+        if not asset:
+            continue
+        route = route_exists(asset, target)
+        if route:
+            return route
+    return None
+
+
+def get_trade_flow(start_time: int, end_time: int, limit: int = 100) -> Dict[str, Any]:
+    params = {"startTime": int(start_time), "endTime": int(end_time), "limit": int(limit)}
+    return binance_client.get("/sapi/v1/convert/tradeFlow", params, signed=True)

--- a/src/core/ensure_invested.py
+++ b/src/core/ensure_invested.py
@@ -1,0 +1,124 @@
+"""Execute Convert rebalance plan with anti-spam safeguards."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+from . import convert_api
+from .portfolio import RebalanceAction
+from .utils import decimal_from_any, ensure_parent, now_ms
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _load_history(path: Path) -> List[dict]:
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except Exception:
+        return []
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def _save_history(path: Path, entries: Sequence[dict]) -> None:
+    ensure_parent(path)
+    path.write_text(json.dumps(list(entries), separators=(",", ":")))
+
+
+def _append_trade_log(path: Path, text: str) -> None:
+    ensure_parent(path)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(text + "\n")
+
+
+def execute_plan(
+    region: str,
+    actions: Sequence[RebalanceAction],
+    log_dir: Path,
+    wallet: str = "SPOT",
+    dry_run: bool = False,
+    tolerance: float = 0.01,
+) -> List[dict]:
+    """Execute rebalance actions returning Convert responses."""
+
+    responses: List[dict] = []
+    history_path = log_dir / "convert_history.json"
+    history = _load_history(history_path)
+    trade_log_path = log_dir / f"trade.{region}.log"
+
+    convert_api.reset_dedup_cache()
+
+    for action in actions:
+        amount_dec = decimal_from_any(action.amount)
+        if amount_dec <= Decimal("0"):
+            continue
+        route = action.route
+        route_desc = " -> ".join(f"{step.from_asset}->{step.to_asset}" for step in route.steps)
+        log_prefix = f"{datetime.utcnow().isoformat()}Z {region}"
+        if dry_run:
+            text = f"{log_prefix} DRY {route_desc} amount={float(amount_dec)}"
+            _append_trade_log(trade_log_path, text)
+            history.append(
+                {
+                    "ts": now_ms(),
+                    "region": region,
+                    "route": route_desc,
+                    "amount": float(amount_dec),
+                    "wallet": wallet,
+                    "status": "dry_run",
+                }
+            )
+            continue
+        try:
+            exec_responses = convert_api.execute_unique(route, amount_dec, wallet, tolerance)
+            if not exec_responses:
+                continue
+        except Exception as exc:  # pragma: no cover - network
+            LOGGER.error("Convert execution failed for %s: %s", route_desc, exc)
+            history.append(
+                {
+                    "ts": now_ms(),
+                    "region": region,
+                    "route": route_desc,
+                    "amount": float(amount_dec),
+                    "wallet": wallet,
+                    "status": "failed",
+                    "error": str(exc),
+                }
+            )
+            continue
+
+        for payload in exec_responses:
+            quote = payload.get("quote", {}) if isinstance(payload, dict) else {}
+            order_id = payload.get("orderId") if isinstance(payload, dict) else None
+            quote_id = quote.get("quoteId") if isinstance(quote, dict) else None
+            to_amount = quote.get("toAmount") or quote.get("toAmountExpected")
+            entry = {
+                "ts": now_ms(),
+                "region": region,
+                "route": route_desc,
+                "amount": float(amount_dec),
+                "wallet": wallet,
+                "orderId": order_id,
+                "quoteId": quote_id,
+                "toAmount": to_amount,
+                "status": "executed",
+            }
+            history.append(entry)
+            responses.append(payload)
+            text = (
+                f"{log_prefix} EXEC {route_desc} amount={float(amount_dec)} "
+                f"order={order_id} quote={quote_id} toAmount={to_amount}"
+            )
+            _append_trade_log(trade_log_path, text)
+
+    _save_history(history_path, history)
+    return responses

--- a/src/core/guard.py
+++ b/src/core/guard.py
@@ -1,0 +1,73 @@
+"""Panic guard logic (15% drawdown rules)."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import List
+
+from . import balance, convert_api
+from .ensure_invested import execute_plan
+from .portfolio import BalanceSnapshot, RebalanceAction
+from .position import PositionState, save as save_position, sync_from_balances
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class GuardResult:
+    triggered: bool
+    asset_triggers: List[str]
+    portfolio_trigger: bool
+
+
+def run_guard(
+    region: str,
+    snapshot: BalanceSnapshot,
+    position_state: PositionState,
+    dry_run: bool = False,
+) -> GuardResult:
+    price_map = snapshot.price_map
+    actions: List[RebalanceAction] = []
+    triggered_assets: List[str] = []
+    portfolio_trigger = False
+
+    for asset, amount in position_state.assets.items():
+        if asset == "USDT" or amount <= 0:
+            continue
+        peak_price = position_state.peaks.get(asset, 0.0)
+        last_price = price_map.get(asset, 0.0)
+        if peak_price <= 0 or last_price <= 0:
+            continue
+        if last_price <= peak_price * 0.85:
+            route = convert_api.route_exists(asset, "USDT")
+            if not route:
+                continue
+            actions.append(RebalanceAction(asset, "USDT", amount, route))
+            triggered_assets.append(asset)
+
+    equity_now = position_state.equity(price_map)
+    if position_state.portfolio_peak > 0 and equity_now <= position_state.portfolio_peak * 0.85:
+        portfolio_trigger = True
+        actions = []
+        triggered_assets = []
+        for asset, amount in position_state.assets.items():
+            if asset == "USDT" or amount <= 0:
+                continue
+            route = convert_api.route_exists(asset, "USDT")
+            if not route:
+                continue
+            actions.append(RebalanceAction(asset, "USDT", amount, route))
+            triggered_assets.append(asset)
+
+    if not actions:
+        return GuardResult(False, [], False)
+
+    execute_plan(region, actions, snapshot.log_dir, dry_run=dry_run)
+
+    if not dry_run:
+        balances = balance.read_all("SPOT")
+        new_state = sync_from_balances(balances, price_map, position_state)
+        save_position(new_state)
+
+    return GuardResult(True, triggered_assets, portfolio_trigger)

--- a/src/core/portfolio.py
+++ b/src/core/portfolio.py
@@ -1,0 +1,294 @@
+"""Portfolio construction helpers."""
+
+from __future__ import annotations
+
+import csv
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Set
+
+import requests
+
+import config_dev3 as config
+
+from . import balance, convert_api
+from .convert_api import ConvertRoute
+from .utils import DECIMAL_ZERO, decimal_from_any, rolling_log_directory
+
+LOGGER = logging.getLogger(__name__)
+
+
+LOG_ROOT = getattr(config, "CONVERT_LOG_ROOT", "/srv/dev3/logs/convert")
+
+DENY_SUFFIXES = ("UP", "DOWN", "BULL", "BEAR", "5L", "5S", "PERP")
+
+
+@dataclass
+class BalanceRow:
+    asset: str
+    amount: Decimal
+    normalised: Optional[str]
+    convertible: bool
+    reason: str
+
+
+@dataclass
+class BalanceSnapshot:
+    rows: List[BalanceRow]
+    from_assets: Set[str]
+    price_map: Dict[str, float]
+    log_dir: Path
+
+    def balances(self) -> Dict[str, Decimal]:
+        return {r.normalised or r.asset: r.amount for r in self.rows if r.amount > 0}
+
+
+@dataclass
+class TargetAllocation:
+    asset: str
+    weight: float
+    quote_amount: Decimal
+    route: ConvertRoute
+    min_quote: float
+    max_quote: float
+    candidate: Dict[str, Any]
+
+
+@dataclass
+class RebalanceAction:
+    from_asset: str
+    to_asset: str
+    amount: Decimal
+    route: ConvertRoute
+
+
+def _normalise_asset(asset: str) -> Optional[str]:
+    asset = (asset or "").upper().strip()
+    if not asset:
+        return None
+    for suffix in DENY_SUFFIXES:
+        if asset.endswith(suffix):
+            return None
+    if asset.startswith("LD") and asset.endswith("UP"):
+        return None
+    if asset.endswith("USDT") and asset != "USDT":
+        prefix = asset[:-4]
+        while prefix and prefix[0].isdigit():
+            prefix = prefix[1:]
+        if prefix:
+            asset = prefix
+    return asset
+
+
+def _price_map_from_tickers() -> Dict[str, float]:
+    try:
+        payload = convert_api.binance_client.public_get("/api/v3/ticker/24hr")
+    except requests.RequestException as exc:  # pragma: no cover - network
+        LOGGER.warning("24hr ticker fetch failed: %s", exc)
+        return {}
+    prices: Dict[str, float] = {}
+    if isinstance(payload, list):
+        for row in payload:
+            symbol = (row.get("symbol") or "").upper()
+            if symbol.endswith("USDT") and len(symbol) > 4:
+                base = symbol[:-4]
+                try:
+                    prices[base] = float(row.get("lastPrice") or 0.0)
+                except (ValueError, TypeError):
+                    continue
+    return prices
+
+
+def pre_analyze_balance_snapshot(ts: float | None = None) -> BalanceSnapshot:
+    log_dir = rolling_log_directory(LOG_ROOT, ts)
+    price_map = _price_map_from_tickers()
+    rows: List[BalanceRow] = []
+    from_assets: Set[str] = set()
+    balances_map = balance.read_all("SPOT")
+    for asset, amount in sorted((balances_map or {}).items()):
+        dec = decimal_from_any(amount)
+        if dec <= DECIMAL_ZERO:
+            continue
+        normalised = _normalise_asset(asset)
+        convertible = False
+        reason = ""
+        if normalised is None:
+            reason = "blocked_suffix"
+        else:
+            route = convert_api.route_exists(normalised, "USDT")
+            if route:
+                convertible = True
+                from_assets.add(normalised)
+            else:
+                for hub in convert_api.HUB_ASSETS:
+                    if convert_api.route_exists(normalised, hub):
+                        convertible = True
+                        from_assets.add(normalised)
+                        break
+                if not convertible:
+                    reason = "no_convert_route"
+        rows.append(
+            BalanceRow(
+                asset=_normalise_asset(asset) or asset,
+                amount=dec,
+                normalised=normalised,
+                convertible=convertible,
+                reason=reason,
+            )
+        )
+    from_assets.add("USDT")
+    csv_path = log_dir / "balance.pre.csv"
+    with csv_path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["asset", "amount", "normalised", "convertible", "reason"])
+        for row in rows:
+            writer.writerow(
+                [
+                    row.asset,
+                    float(row.amount),
+                    row.normalised or "",
+                    "yes" if row.convertible else "no",
+                    row.reason,
+                ]
+            )
+    return BalanceSnapshot(rows=rows, from_assets=from_assets, price_map=price_map, log_dir=log_dir)
+
+
+def _base_weights(count: int) -> Sequence[float]:
+    if count >= 3:
+        return (0.6, 0.3, 0.1)
+    if count == 2:
+        return (0.7, 0.3)
+    if count == 1:
+        return (1.0,)
+    return ()
+
+
+def build_target_allocation(
+    candidates: Sequence[Dict[str, Any]],
+    total_equity: float,
+    from_assets: Iterable[str],
+) -> List[TargetAllocation]:
+    from_assets_set = {asset.upper() for asset in from_assets}
+    usable: List[tuple[Dict[str, Any], convert_api.ConvertRoute]] = []
+    for candidate in candidates[:3]:
+        base = (candidate.get("base") or "").upper()
+        if not base:
+            continue
+        route = convert_api.preferred_route(from_assets_set, base)
+        if not route:
+            continue
+        usable.append((dict(candidate), route))
+    if not usable or total_equity <= 0:
+        return []
+
+    selected: List[TargetAllocation] = []
+    pool = usable
+    while pool:
+        weights = _base_weights(len(pool))
+        temp: List[TargetAllocation] = []
+        removed = False
+        for weight, item in zip(weights, pool):
+            candidate, route = item
+            min_quote = float(candidate.get("min_quote") or 0.0)
+            max_quote = float(candidate.get("max_quote") or 0.0)
+            quote_amount = Decimal(str(total_equity * weight))
+            if min_quote > 0 and quote_amount < Decimal(str(min_quote)) and len(pool) > 1:
+                pool = [c for c in pool if c is not item]
+                removed = True
+                break
+            if max_quote > 0 and quote_amount > Decimal(str(max_quote)):
+                quote_amount = Decimal(str(max_quote))
+            temp.append(
+                TargetAllocation(
+                    asset=candidate.get("base"),
+                    weight=float(weight),
+                    quote_amount=quote_amount,
+                    route=route,
+                    min_quote=min_quote,
+                    max_quote=max_quote,
+                    candidate=candidate,
+                )
+            )
+        if removed:
+            continue
+        selected = temp
+        break
+    return selected
+
+
+def plan_rebalance(
+    holdings: Mapping[str, Decimal],
+    price_map: Mapping[str, float],
+    targets: Sequence[TargetAllocation],
+    threshold: float = 0.08,
+) -> List[RebalanceAction]:
+    actions: List[RebalanceAction] = []
+    holdings_map: MutableMapping[str, Decimal] = {
+        (k or "").upper(): decimal_from_any(v) for k, v in holdings.items()
+    }
+    total_equity = sum(
+        float(amount) * (price_map.get(asset, 1.0) if asset != "USDT" else 1.0)
+        for asset, amount in holdings_map.items()
+    )
+    if total_equity <= 0:
+        return []
+
+    for asset, amount in list(holdings_map.items()):
+        if asset in ("USDT",) or any(t.asset == asset for t in targets):
+            continue
+        if amount <= DECIMAL_ZERO:
+            continue
+        route = convert_api.route_exists(asset, "USDT")
+        if not route:
+            continue
+        actions.append(RebalanceAction(asset, "USDT", amount, route))
+        usdt_notional = decimal_from_any(amount) * Decimal(str(price_map.get(asset, 0.0)))
+        holdings_map[asset] = DECIMAL_ZERO
+        holdings_map["USDT"] = holdings_map.get("USDT", DECIMAL_ZERO) + usdt_notional
+
+    total_equity = sum(
+        float(amount) * (price_map.get(asset, 1.0) if asset != "USDT" else 1.0)
+        for asset, amount in holdings_map.items()
+    )
+    if total_equity <= 0:
+        return actions
+
+    for target in targets:
+        asset = (target.asset or "").upper()
+        price = Decimal(str(price_map.get(asset, 0.0) or 0.0))
+        if price <= 0:
+            continue
+        current_units = holdings_map.get(asset, DECIMAL_ZERO)
+        current_notional = current_units * price
+        desired_notional = target.quote_amount
+        diff = current_notional - desired_notional
+        share_diff = float(diff) / total_equity if total_equity else 0.0
+        if abs(share_diff) <= threshold:
+            continue
+        if diff > 0:
+            amount_units = diff / price
+            route = convert_api.route_exists(asset, "USDT")
+            if not route or amount_units <= DECIMAL_ZERO:
+                continue
+            actions.append(RebalanceAction(asset, "USDT", amount_units, route))
+            holdings_map[asset] = max(DECIMAL_ZERO, current_units - amount_units)
+            holdings_map["USDT"] = holdings_map.get("USDT", DECIMAL_ZERO) + diff
+        else:
+            need_notional = -diff
+            usdt_available = holdings_map.get("USDT", DECIMAL_ZERO)
+            if usdt_available <= DECIMAL_ZERO:
+                continue
+            spend = min(usdt_available, need_notional)
+            if spend <= DECIMAL_ZERO:
+                continue
+            route = convert_api.route_exists("USDT", asset)
+            if not route:
+                continue
+            actions.append(RebalanceAction("USDT", asset, spend, route))
+            holdings_map["USDT"] = max(DECIMAL_ZERO, usdt_available - spend)
+            holdings_map[asset] = holdings_map.get(asset, DECIMAL_ZERO) + spend / price
+
+    return actions

--- a/src/core/position.py
+++ b/src/core/position.py
@@ -1,0 +1,113 @@
+"""Portfolio position persistence and peak tracking."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from decimal import Decimal
+from pathlib import Path
+from typing import Dict, Mapping
+
+import config_dev3 as config
+
+from .utils import DECIMAL_ZERO, decimal_from_any, ensure_parent, now_ms
+
+
+DEFAULT_STATE_PATH = Path(
+    getattr(config, "POSITION_STATE_PATH", "/srv/dev3/state/position.json")
+)
+
+
+def _normalise_asset(asset: str) -> str:
+    return (asset or "").upper().strip()
+
+
+def _price_for(asset: str, price_map: Mapping[str, float]) -> float:
+    if asset == "USDT":
+        return 1.0
+    return float(price_map.get(asset, 0.0) or 0.0)
+
+
+@dataclass
+class PositionState:
+    assets: Dict[str, Decimal] = field(default_factory=dict)
+    peaks: Dict[str, float] = field(default_factory=dict)
+    portfolio_peak: float = 0.0
+    ts: int = field(default_factory=now_ms)
+
+    def equity(self, price_map: Mapping[str, float]) -> float:
+        total = 0.0
+        for asset, amount in self.assets.items():
+            total += float(amount) * _price_for(asset, price_map)
+        return total
+
+    def update_peaks(self, price_map: Mapping[str, float]) -> None:
+        for asset, amount in self.assets.items():
+            if amount <= 0:
+                continue
+            price = _price_for(asset, price_map)
+            if price <= 0:
+                continue
+            self.peaks[asset] = max(self.peaks.get(asset, 0.0), price)
+        equity_now = self.equity(price_map)
+        self.portfolio_peak = max(self.portfolio_peak, equity_now)
+        self.ts = now_ms()
+
+
+def load(path: Path | None = None) -> PositionState:
+    path = path or DEFAULT_STATE_PATH
+    if not path.exists():
+        return PositionState()
+    try:
+        payload = json.loads(path.read_text())
+    except Exception:
+        return PositionState()
+    assets: Dict[str, Decimal] = {}
+    for asset, amount in (payload.get("assets") or {}).items():
+        value = decimal_from_any(amount)
+        if value > 0:
+            assets[_normalise_asset(asset)] = value
+    peaks = {
+        _normalise_asset(k): float(v)
+        for k, v in (payload.get("peaks") or {}).items()
+        if v is not None
+    }
+    return PositionState(
+        assets=assets,
+        peaks=peaks,
+        portfolio_peak=float(payload.get("portfolio_peak", 0.0) or 0.0),
+        ts=int(payload.get("ts", now_ms())),
+    )
+
+
+def save(state: PositionState, path: Path | None = None) -> None:
+    path = path or DEFAULT_STATE_PATH
+    ensure_parent(path)
+    payload = {
+        "assets": {k: float(v) for k, v in state.assets.items()},
+        "peaks": {k: float(v) for k, v in state.peaks.items()},
+        "portfolio_peak": float(state.portfolio_peak),
+        "ts": int(state.ts),
+    }
+    path.write_text(json.dumps(payload, separators=(",", ":")))
+
+
+def sync_from_balances(
+    balances: Mapping[str, Decimal | float | str],
+    price_map: Mapping[str, float],
+    previous: PositionState | None = None,
+) -> PositionState:
+    state = previous or PositionState()
+    state.assets = {
+        _normalise_asset(asset): decimal_from_any(amount)
+        for asset, amount in balances.items()
+        if decimal_from_any(amount) > DECIMAL_ZERO
+    }
+    state.update_peaks(price_map)
+    return state
+
+
+def clear(path: Path | None = None) -> None:
+    path = path or DEFAULT_STATE_PATH
+    if path.exists():
+        path.unlink()

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation, ROUND_DOWN
-from typing import Any, Tuple
+from pathlib import Path
+from typing import Any, Iterable, Tuple
 
+import math
+import random
 import time
+
+
+DECIMAL_ZERO = Decimal("0")
 
 
 def now_ms() -> int:
@@ -33,6 +39,61 @@ def floor_str_8(value: Decimal) -> str:
     return as_str or "0"
 
 
+def decimal_from_any(value: Any, default: Decimal | None = None) -> Decimal:
+    """Coerce *value* into :class:`~decimal.Decimal`.
+
+    ``default`` is returned when *value* cannot be represented as a Decimal.
+    """
+
+    if value is None:
+        return DECIMAL_ZERO if default is None else default
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return DECIMAL_ZERO if default is None else default
+
+
+def clamp(value: float, lower: float, upper: float) -> float:
+    """Return ``value`` constrained to ``[lower, upper]``."""
+
+    return max(lower, min(upper, value))
+
+
+def rolling_log_directory(base: str, ts: float | None = None) -> Path:
+    """Return the per-day log directory creating it if necessary."""
+
+    ts = ts or time.time()
+    day = datetime.utcfromtimestamp(ts).strftime("%Y-%m-%d")
+    path = Path(base).expanduser().resolve() / day
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def ensure_parent(path: Path) -> None:
+    """Create parent directory for *path* if missing."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def rand_jitter(seconds_range: Iterable[float] | None) -> float:
+    """Return a random jitter duration in seconds."""
+
+    if not seconds_range:
+        return 0.0
+    seq = tuple(seconds_range)
+    if not seq:
+        return 0.0
+    if len(seq) == 1:
+        return float(seq[0])
+    low = float(seq[0])
+    high = float(seq[-1])
+    if math.isclose(low, high):
+        return low
+    return random.uniform(min(low, high), max(low, high))
+
+
 def _extract_limits(exchange_info: dict) -> Tuple[Decimal, Decimal]:
     payload: Any = exchange_info
     if isinstance(exchange_info, dict) and "data" in exchange_info:
@@ -43,16 +104,7 @@ def _extract_limits(exchange_info: dict) -> Tuple[Decimal, Decimal]:
     max_raw = (
         None if not isinstance(payload, dict) else payload.get("fromAssetMaxAmount")
     )
-    return _to_decimal(min_raw), _to_decimal(max_raw)
-
-
-def _to_decimal(value: Any) -> Decimal:
-    if value is None:
-        return Decimal("0")
-    try:
-        return Decimal(str(value))
-    except (InvalidOperation, ValueError, TypeError):
-        return Decimal("0")
+    return decimal_from_any(min_raw), decimal_from_any(max_raw)
 
 
 def ensure_amount_and_limits(exchange_info: dict, amount_dec: Decimal) -> None:

--- a/src/strategy/selector.py
+++ b/src/strategy/selector.py
@@ -1,52 +1,215 @@
+"""Candidate selection for Convert trades."""
+
 from __future__ import annotations
-import os
-from typing import Dict, Any, List, Set
-from src.core import balance
 
-def _env_targets() -> List[str]:
-    raw = os.environ.get("CONVERT_TARGETS", "").strip()
-    if not raw:
-        return []
-    return [t.strip().upper() for t in raw.split(",") if t.strip()]
+import csv
+import json
+import logging
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
 
-def _positive_assets(min_notional: float, wallet: str) -> Dict[str, float]:
-    res: Dict[str, float] = {}
-    bals = balance.read_all(wallet) or {}
-    if isinstance(bals, dict):
-        items = bals.items()
-    else:
-        items = []
-    for asset, free in items:
-        try:
-            f = float(free or 0)
-        except Exception:
-            f = 0.0
-        if f > min_notional:
-            res[str(asset).upper()] = f
-    return res
+import requests
 
-def select_routes_for_phase(region: str, phase: str) -> List[Dict[str, Any]]:
+import config_dev3 as config
+
+from src.core import convert_api
+from src.core.convert_api import ConvertRoute
+from src.core.portfolio import BalanceSnapshot
+from src.core.utils import clamp
+
+LOGGER = logging.getLogger(__name__)
+
+
+REGION_BIAS = {"us": 1.05, "asia": 1.03}
+DEFAULT_MIN_VOLUME = getattr(config, "MIN_VOLUME_USDT", 5_000_000)
+DEFAULT_MAX_SPREAD_BPS = getattr(config, "MAX_SPREAD_BPS", 5.0)
+TOP_K = getattr(config, "TOP_K", 5)
+
+
+@dataclass
+class Candidate:
+    rank: int
+    symbol: str
+    base: str
+    score: float
+    qvol: float
+    chg: float
+    spread_bps: float
+    last_price: float
+    route: ConvertRoute
+    route_desc: str
+    min_quote: float
+    max_quote: float
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "rank": self.rank,
+            "symbol": self.symbol,
+            "base": self.base,
+            "score": self.score,
+            "qVol": self.qvol,
+            "chg": self.chg,
+            "spread_bps": self.spread_bps,
+            "last_price": self.last_price,
+            "route": self.route_desc,
+            "min_quote": self.min_quote,
+            "max_quote": self.max_quote,
+            "route_steps": [
+                {"from": step.from_asset, "to": step.to_asset} for step in self.route.steps
+            ],
+        }
+
+
+def _normalise_base(symbol: str) -> tuple[str, str]:
+    symbol = symbol.upper()
+    if symbol.endswith("USDT"):
+        return symbol[:-4], "USDT"
+    return symbol, ""
+
+
+def _route_description(route: ConvertRoute) -> str:
+    if route.is_direct:
+        return "direct"
+    hubs = [step.to_asset for step in route.steps[:-1]]
+    return "hub:" + "|".join(hubs)
+
+
+def _compute_spread_bps(bid: float, ask: float) -> float:
+    if bid <= 0 or ask <= 0:
+        return 999.0
+    mid = (bid + ask) / 2.0
+    if mid <= 0:
+        return 999.0
+    return abs(ask - bid) / mid * 10_000
+
+
+def _score_item(qvol: float, chg_pct: float, spread_bps: float, region: str) -> float:
+    liquidity = math.log10(max(qvol, 0.0) + 1.0)
+    momentum = 1.0 + clamp(chg_pct, -50.0, 50.0) / 100.0
+    spread_penalty = 1.0 + (spread_bps / 10.0)
+    base_score = max(0.0, liquidity * momentum / spread_penalty)
+    bias = REGION_BIAS.get(region, 1.0)
+    return base_score * bias
+
+
+def _route_limits(route: ConvertRoute) -> tuple[float, float]:
+    if not route.steps:
+        return 0.0, 0.0
+    first = route.steps[0]
+    limits = convert_api.limits_for_pair(first.from_asset, first.to_asset)
+    return float(limits.minimum), float(limits.maximum)
+
+
+def select_candidates(
+    region: str,
+    snapshot: BalanceSnapshot,
+    min_volume: float = DEFAULT_MIN_VOLUME,
+    max_spread_bps: float = DEFAULT_MAX_SPREAD_BPS,
+    top_k: int = TOP_K,
+) -> List[Candidate]:
     try:
-        min_notional = float(os.environ.get("MIN_NOTIONAL", "1.0"))
-    except Exception:
-        min_notional = 1.0
-    wallet = os.environ.get("DEFAULT_WALLET", "SPOT").upper()
+        tickers = convert_api.binance_client.public_get("/api/v3/ticker/24hr")
+    except requests.RequestException as exc:  # pragma: no cover - network
+        LOGGER.error("ticker/24hr fetch failed: %s", exc)
+        return []
+    from_assets = snapshot.from_assets
+    rejections: Dict[str, int] = {}
+    candidates: List[Candidate] = []
 
-    pos = _positive_assets(min_notional, wallet)
-    targets_env = _env_targets()
+    if not isinstance(tickers, list):
+        return []
 
-    routes: List[Dict[str, Any]] = []
-    assets: List[str] = sorted(pos.keys())
-    assets_set: Set[str] = set(assets)
-
-    for fa in assets:
-        amount = pos.get(fa, 0.0)
-        if amount <= 0:
+    for row in tickers:
+        symbol = (row.get("symbol") or "").upper()
+        base, quote = _normalise_base(symbol)
+        if quote != "USDT":
             continue
-        if targets_env:
-            tos = [t for t in targets_env if t != fa]
-        else:
-            tos = [t for t in assets if t != fa]
-        for ta in tos:
-            routes.append({"from": fa, "to": ta, "wallet": wallet, "amount": amount})
-    return routes
+        last_price = float(row.get("lastPrice") or 0.0)
+        qvol = float(row.get("quoteVolume") or 0.0)
+        if qvol < min_volume:
+            rejections["low_volume"] = rejections.get("low_volume", 0) + 1
+            continue
+        bid = float(row.get("bidPrice") or 0.0)
+        ask = float(row.get("askPrice") or 0.0)
+        spread_bps = _compute_spread_bps(bid, ask)
+        if spread_bps > max_spread_bps:
+            rejections["wide_spread"] = rejections.get("wide_spread", 0) + 1
+            continue
+        route = convert_api.preferred_route(from_assets, base)
+        if not route:
+            rejections["no_route"] = rejections.get("no_route", 0) + 1
+            continue
+        chg_pct = float(row.get("priceChangePercent") or 0.0)
+        score = _score_item(qvol, chg_pct, spread_bps, region)
+        min_quote, max_quote = _route_limits(route)
+        candidate = Candidate(
+            rank=0,
+            symbol=symbol,
+            base=base,
+            score=score,
+            qvol=qvol,
+            chg=chg_pct,
+            spread_bps=spread_bps,
+            last_price=last_price,
+            route=route,
+            route_desc=_route_description(route),
+            min_quote=min_quote,
+            max_quote=max_quote,
+        )
+        candidates.append(candidate)
+
+    candidates.sort(key=lambda c: c.score, reverse=True)
+    selected = candidates[: top_k or len(candidates)]
+    for idx, cand in enumerate(selected, start=1):
+        cand.rank = idx
+
+    summary_path = snapshot.log_dir / "summary.txt"
+    with summary_path.open("a", encoding="utf-8") as fh:
+        fh.write(f"Region={region} Total={len(selected)}\n")
+        if rejections:
+            fh.write("Rejections:" + "\n")
+            for key, val in sorted(rejections.items()):
+                fh.write(f"  {key}: {val}\n")
+
+    csv_path = snapshot.log_dir / f"candidates.{region}.csv"
+    with csv_path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(
+            [
+                "rank",
+                "symbol",
+                "base",
+                "score",
+                "qVol",
+                "chg",
+                "spread_bps",
+                "last_price",
+                "route",
+                "min_quote",
+                "max_quote",
+            ]
+        )
+        for cand in selected:
+            writer.writerow(
+                [
+                    cand.rank,
+                    cand.symbol,
+                    cand.base,
+                    cand.score,
+                    cand.qvol,
+                    cand.chg,
+                    cand.spread_bps,
+                    cand.last_price,
+                    cand.route_desc,
+                    cand.min_quote,
+                    cand.max_quote,
+                ]
+            )
+
+    json_path = snapshot.log_dir / f"candidates.{region}.json"
+    with json_path.open("w", encoding="utf-8") as fh:
+        json.dump([cand.as_dict() for cand in selected], fh, indent=2)
+
+    return selected


### PR DESCRIPTION
## Summary
- add portfolio, position, guard, and ensure_invested modules to manage convert balances, allocations, and panic actions
- expand convert API, Binance client utilities, and selector logic to score markets, respect limits, and execute direct or hub routes with logging
- update app orchestration and CLI phase handling for analyze, trade, and guard flows with per-day artifacts

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d512912a6883299592b1a106d0430b